### PR TITLE
incorrect-fsf-address part of issue #18

### DIFF
--- a/libmate-desktop/libmate/mate-desktop-item.h
+++ b/libmate-desktop/libmate/mate-desktop-item.h
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the Mate Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA  02110-1301, USA.  */
 /*
   @NOTATION@
  */

--- a/libmate-desktop/libmate/mate-desktop-utils.h
+++ b/libmate-desktop/libmate/mate-desktop-utils.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the Mate Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA  02110-1301, USA.  */
 /*
   @NOTATION@
  */

--- a/libmate-desktop/libmateui/mate-bg.h
+++ b/libmate-desktop/libmateui/mate-bg.h
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the Mate Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA  02110-1301, USA.
 
    Author: Soren Sandmann <sandmann@redhat.com>
 */

--- a/libmate-desktop/libmateui/mate-desktop-thumbnail.h
+++ b/libmate-desktop/libmateui/mate-desktop-thumbnail.h
@@ -17,8 +17,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with the Mate Library; see the file COPYING.LIB.  If not,
- * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
  *
  * Author: Alexander Larsson <alexl@redhat.com>
  */

--- a/libmate-desktop/libmateui/mate-rr-config.h
+++ b/libmate-desktop/libmateui/mate-rr-config.h
@@ -16,8 +16,8 @@
  * 
  * You should have received a copy of the GNU Library General Public
  * License along with the Mate Library; see the file COPYING.LIB.  If not,
- * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
  * 
  * Author: Soren Sandmann <sandmann@redhat.com>
  */

--- a/libmate-desktop/libmateui/mate-rr-labeler.h
+++ b/libmate-desktop/libmateui/mate-rr-labeler.h
@@ -17,8 +17,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with the Mate Library; see the file COPYING.LIB.  If not,
- * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
  *
  * Author: Federico Mena-Quintero <federico@novell.com>
  */

--- a/libmate-desktop/libmateui/mate-rr.h
+++ b/libmate-desktop/libmateui/mate-rr.h
@@ -16,8 +16,8 @@
  * 
  * You should have received a copy of the GNU Library General Public
  * License along with the Mate Library; see the file COPYING.LIB.  If not,
- * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
  * 
  * Author: Soren Sandmann <sandmann@redhat.com>
  */


### PR DESCRIPTION
test after fix

[rave@mother ~]$ rpmlint /home/rave/rpmbuild/RPMS/x86_64/mate-desktop-1.4.1-5.fc16.x86_64.rpm
mate-desktop.x86_64: W: spelling-error %description -l en_US libmatedesktop -> desktop
mate-desktop.x86_64: E: invalid-desktopfile /usr/share/applications/mate-about.desktop value 
"MATE;GTK;Core;Utility;" for key "Categories" in group "Desktop Entry" contains an unregistered value "MATE"; values extending the format should start with "X-"
1 packages and 0 specfiles checked; 1 errors, 1 warnings.

the first error is gone
