### PR TITLE
Use -lm when we use math functions.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -286,6 +286,8 @@ if test "x$enable_rebuilds" = "xyes" && \
 fi
 AC_SUBST(REBUILD)
 
+AC_SEARCH_LIBS([sqrt], [m])
+
 # check for gtk-doc
 GTK_DOC_CHECK([1.4])
 


### PR DESCRIPTION
Just like with libmatekbd, we are underlinking so we need -lm when using sqrt, floor, fmod and pow.

Signed-off-by: Steev Klimaszewski steev@gentoo.org
