### PR TITLE
Fix desktop schema paths

### DIFF
--- a/schemas/org.mate.accessibility-keyboard.gschema.xml.in.in
+++ b/schemas/org.mate.accessibility-keyboard.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.accessibility-keyboard" path="/desktop/mate/accessibility/keyboard/">
+  <schema id="org.mate.accessibility-keyboard" path="/org/mate/desktop/accessibility/keyboard/">
     <key name="enable" type="b">
       <default>false</default>
     </key>

--- a/schemas/org.mate.accessibility-startup.gschema.xml.in.in
+++ b/schemas/org.mate.accessibility-startup.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.accessibility-startup" path="/desktop/mate/accessibility/startup/">
+  <schema id="org.mate.accessibility-startup" path="/org/mate/desktop/accessibility/startup/">
     <key name="exec-ats" type="as">
       <default>[]</default>
       <_summary>Startup Assistive Technology Applications</_summary>

--- a/schemas/org.mate.applications-at-mobility.gschema.xml.in.in
+++ b/schemas/org.mate.applications-at-mobility.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-at-mobility" path="/desktop/mate/applications/at/mobility/">
+  <schema id="org.mate.applications-at-mobility" path="/org/mate/desktop/applications/at/mobility/">
     <key name="exec" type="s">
       <default>'dasher'</default>
       <_summary>Preferred Mobility assistive technology application</_summary>

--- a/schemas/org.mate.applications-at-visual.gschema.xml.in.in
+++ b/schemas/org.mate.applications-at-visual.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-at-visual" path="/desktop/mate/applications/at/visual/">
+  <schema id="org.mate.applications-at-visual" path="/org/mate/desktop/applications/at/visual/">
     <key name="exec" type="s">
       <default>'orca'</default>
       <_summary>Preferred Visual assistive technology application</_summary>

--- a/schemas/org.mate.applications-browser.gschema.xml.in.in
+++ b/schemas/org.mate.applications-browser.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-browsser" path="/desktop/mate/applications/browser/">
+  <schema id="org.mate.applications-browsser" path="/org/mate/desktop/applications/browser/">
     <key name="exec" type="s">
       <default>'mozilla'</default>
       <_summary>Default browser</_summary>

--- a/schemas/org.mate.applications-office.gschema.xml.in.in
+++ b/schemas/org.mate.applications-office.gschema.xml.in.in
@@ -1,9 +1,9 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-office" path="/desktop/mate/applications/">
+  <schema id="org.mate.applications-office" path="/org/mate/desktop/applications/">
     <child name="calendar" schema="org.mate.applications-office.calendar"/>
     <child name="tasks" schema="org.mate.applications-office.tasks"/>
   </schema>
-  <schema id="org.mate.applications-office.calendar" path="/desktop/mate/applications/calendar/">
+  <schema id="org.mate.applications-office.calendar" path="/org/mate/desktop/applications/calendar/">
     <key name="exec" type="s">
       <default>'evolution'</default>
       <_summary>Default calendar</_summary>
@@ -15,7 +15,7 @@
       <_description>Whether the default calendar application needs a terminal to run</_description>
     </key>
   </schema>
-  <schema id="org.mate.applications-office.tasks" path="/desktop/mate/applications/tasks/">
+  <schema id="org.mate.applications-office.tasks" path="/org/mate/desktop/applications/tasks/">
     <key name="exec" type="s">
       <default>'evolution'</default>
       <_summary>Default tasks</_summary>

--- a/schemas/org.mate.applications-terminal.gschema.xml.in.in
+++ b/schemas/org.mate.applications-terminal.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-terminal" path="/desktop/mate/applications/terminal/">
+  <schema id="org.mate.applications-terminal" path="/org/mate/desktop/applications/terminal/">
     <key name="exec" type="s">
       <default>'mate-terminal'</default>
       <_summary>Terminal application</_summary>

--- a/schemas/org.mate.background.gschema.xml.in.in
+++ b/schemas/org.mate.background.gschema.xml.in.in
@@ -12,7 +12,7 @@
 	<value nick="horizontal-gradient" value="1"/>
 	<value nick="vertical-gradient" value="2"/>
   </enum>
-  <schema id="org.mate.background" path="/desktop/mate/background/">
+  <schema id="org.mate.background" path="/org/mate/desktop/background/">
     <key name="draw-background" type="b">
       <default>true</default>
       <_summary>Draw Desktop Background</_summary>

--- a/schemas/org.mate.file-views.gschema.xml.in.in
+++ b/schemas/org.mate.file-views.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.file-views" path="/desktop/mate/file-views/">
+  <schema id="org.mate.file-views" path="/org/mate/desktop/file-views/">
     <key name="icon-theme" type="s">
       <default>'crux_teal'</default>
       <_summary>File Icon Theme</_summary>

--- a/schemas/org.mate.interface.gschema.xml.in.in
+++ b/schemas/org.mate.interface.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.interface" path="/desktop/mate/interface/">
+  <schema id="org.mate.interface" path="/org/mate/desktop/interface/">
     <key name="accessibility" type="b">
       <default>false</default>
       <_summary>Enable Accessibility</_summary>

--- a/schemas/org.mate.lockdown.gschema.xml.in.in
+++ b/schemas/org.mate.lockdown.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.lockdown" path="/desktop/mate/lockdown/">
+  <schema id="org.mate.lockdown" path="/org/mate/desktop/lockdown/">
     <key name="disable-command-line" type="b">
       <default>false</default>
       <_summary>Disable command line</_summary>

--- a/schemas/org.mate.peripherals-keyboard.gschema.xml.in.in
+++ b/schemas/org.mate.peripherals-keyboard.gschema.xml.in.in
@@ -4,7 +4,7 @@
     <value nick="on" value="1"/>
     <value nick="unknown" value="2"/>
   </enum>
-  <schema id="org.mate.peripherals-keyboard" path="/desktop/mate/peripherals/keyboard/">
+  <schema id="org.mate.peripherals-keyboard" path="/org/mate/desktop/peripherals/keyboard/">
     <key name="repeat" type="b">
       <default>true</default>
     </key>

--- a/schemas/org.mate.peripherals-mouse.gschema.xml.in.in
+++ b/schemas/org.mate.peripherals-mouse.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.peripherals-mouse" path="/desktop/mate/peripherals/mouse/">
+  <schema id="org.mate.peripherals-mouse" path="/org/mate/desktop/peripherals/mouse/">
     <key name="left-handed" type="b">
       <default>false</default>
       <_summary>Mouse button orientation</_summary>

--- a/schemas/org.mate.sound.gschema.xml.in.in
+++ b/schemas/org.mate.sound.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.sound" path="/desktop/mate/sound/">
+  <schema id="org.mate.sound" path="/org/mate/desktop/sound/">
     <key name="default-mixer-device" type="s">
       <default>''</default>
       <_summary>Default mixer device</_summary>

--- a/schemas/org.mate.thumbnail-cache.gschema.xml.in.in
+++ b/schemas/org.mate.thumbnail-cache.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.thumbnail-cache" path="/desktop/mate/thumbnail-cache/">
+  <schema id="org.mate.thumbnail-cache" path="/org/mate/desktop/thumbnail-cache/">
     <key name="maximum-age" type="i">
       <default>180</default>
       <_description>Maximum age for thumbnails in the cache, in days. Set to -1 to disable cleaning.</_description>

--- a/schemas/org.mate.thumbnailers.gschema.xml.in.in
+++ b/schemas/org.mate.thumbnailers.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.thumbnailers" path="/desktop/mate/thumbnailers/">
+  <schema id="org.mate.thumbnailers" path="/org/mate/desktop/thumbnailers/">
     <key name="disable-all" type="b">
       <default>false</default>
       <_summary>Disable all external thumbnailers</_summary>

--- a/schemas/org.mate.typing-break.gschema.xml.in.in
+++ b/schemas/org.mate.typing-break.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.typing-break" path="/desktop/mate/typing-break/">
+  <schema id="org.mate.typing-break" path="/org/mate/desktop/typing-break/">
     <key name="type-time" type="i">
       <default>60</default>
       <_summary>Type time</_summary>


### PR DESCRIPTION
This changes /desktop/mate/ to /org/mate/desktop/ in all of the mate-desktop package's schemas. This should resolve issue #29.

Note: There's a typo in org.mate.applications-browsser (extra s in browser), but I didn't fix it since I don't know if any code relies on this misspelling.
