### PR TITLE
Fix typo in browser schema

### DIFF
--- a/schemas/org.mate.applications-browser.gschema.xml.in.in
+++ b/schemas/org.mate.applications-browser.gschema.xml.in.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-browsser" path="/org/mate/desktop/applications/browser/">
+  <schema id="org.mate.applications-browser" path="/org/mate/desktop/applications/browser/">
     <key name="exec" type="s">
       <default>'mozilla'</default>
       <_summary>Default browser</_summary>


### PR DESCRIPTION
This fixes "browsser" -> "browser" in the schema id.

I also noticed /desktop/ paths in mate-keyring. Should these use /org/mate/desktop/ as well (such as /org/mate/desktop/crypto/cache/) or something else (like /org/mate/crypto/cache/)? (The GNOME keyring schemas are still using /desktop/gnome/crypto/cache/ right now.)
