### PR TITLE
[mate-bg] revise setting up root pixmap / transparency

### DIFF
--- a/libmate-desktop/libmateui/mate-bg.h
+++ b/libmate-desktop/libmateui/mate-bg.h
@@ -1,6 +1,7 @@
 /* mate-bg.h -
 
-   Copyright 2007, Red Hat, Inc.
+   Copyright (C) 2007 Red Hat, Inc.
+   Copyright (C) 2012 Jasmine Hassan <jasmine.aura@gmail.com>
 
    This file is part of the Mate Library.
 
@@ -19,7 +20,8 @@
    write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
    Boston, MA  02110-1301, USA.
 
-   Author: Soren Sandmann <sandmann@redhat.com>
+   Authors: Soren Sandmann <sandmann@redhat.com>
+	    Jasmine Hassan <jasmine.aura@gmail.com>
 */
 
 #ifndef __MATE_BG_H__


### PR DESCRIPTION
Part of the original code (from gnome-desktop) for setting root pixmap seems very similar to, and may have been adapted from common source:
http://people.debian.org/~lunar/xwpset.c

The original concept all dates back to an Eterm/Esetroot technique that became commonly used (ex. xchat) for window transparency over desktop:
http://www.eterm.org/docs/view.php?doc=ref#trans

Wisdom can be gained from studying various similar implementations
Examples:
https://github.com/derf/feh/blob/master/src/wallpaper.c
http://ag.cs.uvic.ca/static/debian5/sources/blackbox_0.70.1/blackbox-0.70.1.orig/util/bsetroot.cc
http://files.minuslab.net/SetBG.cc

The changes should hopefully help avoid this: https://bugzilla.gnome.org/show_bug.cgi?id=681928
and consequences as these: https://bugzilla.gnome.org/show_bug.cgi?id=680356
https://bugzilla.gnome.org/show_bug.cgi?id=680354
