### PR TITLE
Middle Click Emulation: add schema key

### DIFF
--- a/schemas/org.mate.peripherals-mouse.gschema.xml.in.in
+++ b/schemas/org.mate.peripherals-mouse.gschema.xml.in.in
@@ -30,6 +30,11 @@
       <_summary>Double Click Time</_summary>
       <_description>Length of a double click.</_description>
     </key>
+    <key name="middle-button-enabled" type="b">
+      <default>false</default>
+      <_summary>Middle button emulation</_summary>
+      <_description>Enables middle mouse button emulation through simultaneous left and right button click.</_description>
+    </key>
     <key name="locate-pointer" type="b">
       <default>false</default>
       <_summary>Locate Pointer</_summary>


### PR DESCRIPTION
This key is needed for the middle mouse click feature in mate-settings-daemon.
