### PR TITLE
fix mate_gdk_spawn_command_line_on_screen

### DIFF
--- a/libmate-desktop/mate-desktop-utils.c
+++ b/libmate-desktop/mate-desktop-utils.c
@@ -190,23 +190,21 @@ mate_gdk_spawn_command_line_on_screen (GdkScreen *screen, const gchar *command, 
 {
 	GAppInfo *appinfo = NULL;
 	GdkAppLaunchContext *context = NULL;
+	gboolean res = FALSE;
 
 	appinfo = g_app_info_create_from_commandline (command, NULL, G_APP_INFO_CREATE_NONE, error);
 
-	if (!error || *error == NULL) {
+	if (appinfo) {
 		context = gdk_app_launch_context_new ();
 		gdk_app_launch_context_set_screen (context, screen);
-		g_app_info_launch (appinfo, NULL, G_APP_LAUNCH_CONTEXT (context), error);
+		res = g_app_info_launch (appinfo, NULL, G_APP_LAUNCH_CONTEXT (context), error);
 		g_object_unref (context);
 	}
 
 	if (appinfo != NULL)
 		g_object_unref (appinfo);
 
-	if (!error || *error == NULL)
-		return TRUE;
-	else
-		return FALSE;
+	return res;
 }
 #endif
 


### PR DESCRIPTION
&error (GError***) cannot be NULL.

use "error" variable only to return error reason
