### PR TITLE
forbid to switch focus between labels

### DIFF
--- a/libmate-desktop/mate-aboutdialog.c
+++ b/libmate-desktop/mate-aboutdialog.c
@@ -498,6 +498,7 @@ mate_about_dialog_init (MateAboutDialog *about)
   gtk_widget_push_composite_child ();
 
   vbox = gtk_vbox_new (FALSE, 8);
+  gtk_container_set_focus_chain (GTK_CONTAINER (vbox), NULL);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 5);
   gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (dialog)), vbox, TRUE, TRUE, 0);
 


### PR DESCRIPTION
set focus chain to NULL, so user can't switch between labels by "tab" button.
