### PR TITLE
mate-thumbnail: first connect to settings, then read them.

### DIFF
--- a/libmate-desktop/mate-desktop-thumbnail.c
+++ b/libmate-desktop/mate-desktop-thumbnail.c
@@ -790,15 +790,18 @@ mate_desktop_thumbnail_factory_init (MateDesktopThumbnailFactory *factory)
   g_mutex_init (&priv->lock);
 
   priv->settings = g_settings_new ("org.mate.thumbnailers");
-  priv->disabled = g_settings_get_boolean (priv->settings, "disable-all");
-  if (!priv->disabled)
-    priv->disabled_types = g_settings_get_strv (priv->settings, "disable");
+
   g_signal_connect (priv->settings, "changed::disable-all",
                     G_CALLBACK (external_thumbnailers_disabled_all_changed_cb),
                     factory);
   g_signal_connect (priv->settings, "changed::disable",
                     G_CALLBACK (external_thumbnailers_disabled_changed_cb),
                     factory);
+
+  priv->disabled = g_settings_get_boolean (priv->settings, "disable-all");
+
+  if (!priv->disabled)
+    priv->disabled_types = g_settings_get_strv (priv->settings, "disable");
 
   if (!priv->disabled)
     mate_desktop_thumbnail_factory_load_thumbnailers (factory);


### PR DESCRIPTION
fixes the issue with GLib >= 2.43,
https://git.gnome.org/browse/glib/commit/?id=8ff5668a458344da22d30491e3ce726d861b3619