### PR TITLE
color select dialog: drop CSD/headerbar usage

### DIFF
--- a/libmate-desktop/mate-colorseldialog.c
+++ b/libmate-desktop/mate-colorseldialog.c
@@ -185,24 +185,6 @@ mate_color_selection_dialog_new (const gchar *title)
   return GTK_WIDGET (colorseldiag);
 }
 
-// since 1.9.1
-#if GTK_CHECK_VERSION (3, 12, 0)
-GtkWidget*
-mate_color_selection_dialog_new_with_header_bar (const gchar *title)
-{
-  MateColorSelectionDialog *colorseldiag;
-  
-  colorseldiag = g_object_new (MATE_TYPE_COLOR_SELECTION_DIALOG, "use-header-bar", TRUE, NULL);
-
-  if (title)
-    gtk_window_set_title (GTK_WINDOW (colorseldiag), title);
-
-  gtk_window_set_resizable (GTK_WINDOW (colorseldiag), FALSE);
-  
-  return GTK_WIDGET (colorseldiag);
-}
-#endif
-
 /**
  * mate_color_selection_dialog_get_color_selection:
  * @colorsel: a #MateColorSelectionDialog

--- a/libmate-desktop/mate-colorseldialog.h
+++ b/libmate-desktop/mate-colorseldialog.h
@@ -69,9 +69,6 @@ struct _MateColorSelectionDialogClass
 /* ColorSelectionDialog */
 GType      mate_color_selection_dialog_get_type            (void) G_GNUC_CONST;
 GtkWidget* mate_color_selection_dialog_new                 (const gchar *title);
-#if GTK_CHECK_VERSION (3, 12, 0)
-GtkWidget* mate_color_selection_dialog_new_with_header_bar (const gchar *title);
-#endif
 GtkWidget* mate_color_selection_dialog_get_color_selection (MateColorSelectionDialog *colorsel);
 
 

--- a/tools/mate-color-select.c
+++ b/tools/mate-color-select.c
@@ -59,13 +59,7 @@ main (int argc, char **argv)
     /* initialize GTK+ */
     gtk_init (&argc, &argv);
 
-#if GTK_CHECK_VERSION (3, 12, 0)
-    color_dialog = mate_color_selection_dialog_new_with_header_bar (_("MATE Color Selection"));
-    gtk_header_bar_set_show_close_button (gtk_dialog_get_header_bar (GTK_DIALOG (color_dialog)), TRUE);
-#else
     color_dialog = mate_color_selection_dialog_new (_("MATE Color Selection"));
-#endif
-
     mate_color_selection_set_has_palette (MATE_COLOR_SELECTION_DIALOG (color_dialog)->colorsel, TRUE);
 
     /* quit signal */


### PR DESCRIPTION
maybe it was relevant with GTK+ 3.12 where the developers forced
CSD on all dialogs, but now it isn't. in GTK+ 3.14 they apparently
realized they were wrong and stopped forcing CSD on dialogs:

http://blogs.gnome.org/mclasen/2014/07/28/a-talk-in-9-images/