### PR TITLE
Remove duplicated typedef

### DIFF
--- a/libmate-desktop/mate-aboutdialog.c
+++ b/libmate-desktop/mate-aboutdialog.c
@@ -67,7 +67,6 @@
 static GdkColor default_link_color = { 0, 0, 0, 0xeeee };
 static GdkColor default_visited_link_color = { 0, 0x5555, 0x1a1a, 0x8b8b };
 
-typedef struct _MateAboutDialogPrivate MateAboutDialogPrivate;
 struct _MateAboutDialogPrivate
 {
   gchar *name;

--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -88,8 +88,6 @@ enum {
   COLORSEL_NUM_CHANNELS
 };
 
-typedef struct _ColorSelectionPrivate ColorSelectionPrivate;
-
 struct _ColorSelectionPrivate
 {
   guint has_opacity : 1;


### PR DESCRIPTION
Such typedefs are in corresponding header files.