### PR TITLE
Revert "changed checking for NULL a bit"

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -2857,14 +2857,9 @@ handle_text (GMarkupParseContext *context,
 	     GError             **err)
 {
 	SlideShow *parser = user_data;
+	Slide *slide = parser->slides->tail? parser->slides->tail->data : NULL;
 	FileSize *fs;
 	gint i;
-
-	g_return_if_fail (parser != NULL);
-	g_return_if_fail (parser->slides != NULL);
-	g_return_if_fail (parser->slides->tail != NULL);
-
-	Slide *slide = parser->slides->tail->data;
 
 	if (stack_is (parser, "year", "starttime", "background", NULL)) {
 		parser->start_tm.tm_year = parse_int (text) - 1900;


### PR DESCRIPTION
This reverts commit 48df7a0c71a2df4050abae40ec9ca2b35dee7988.

The commit causes a regression with timing xml backgrounds.
see https://github.com/mate-desktop/mate-control-center/issues/159