### PR TITLE
port GdkColors to GdkRGBA

### DIFF
--- a/libmate-desktop/mate-bg-crossfade.c
+++ b/libmate-desktop/mate-bg-crossfade.c
@@ -273,9 +273,21 @@ tile_surface (cairo_surface_t *surface,
 	}
 	else
 	{
+#if GTK_CHECK_VERSION (3, 0, 0)
+		GtkStyleContext *context;
+		GdkRGBA bg;
+		context = gtk_style_context_new ();
+		gtk_style_context_add_provider (context,
+										GTK_STYLE_PROVIDER (gtk_css_provider_get_default ()),
+										GTK_STYLE_PROVIDER_PRIORITY_THEME);
+		gtk_style_context_get_background_color (context, GTK_STATE_FLAG_NORMAL, &bg);
+		gdk_cairo_set_source_rgba(cr, &bg);
+		g_object_unref (G_OBJECT (context));
+#else
 		GtkStyle *style;
 		style = gtk_widget_get_default_style ();
 		gdk_cairo_set_source_color(cr, &style->bg[GTK_STATE_NORMAL]);
+#endif
 	}
 
 	cairo_paint (cr);

--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -1306,12 +1306,13 @@ mate_bg_is_dark (MateBG *bg,
 	if (pixbuf) {
 #if GTK_CHECK_VERSION (3, 0, 0)
 		GdkRGBA argb;
+		guchar a, r, g, b;
 
 		pixbuf_average_value (pixbuf, &argb);
-		guchar a = argb.alpha * 0xff;
-		guchar r = argb.red * 0xff;
-		guchar g = argb.green * 0xff;
-		guchar b = argb.blue * 0xff;
+		a = argb.alpha * 0xff;
+		r = argb.red * 0xff;
+		g = argb.green * 0xff;
+		b = argb.blue * 0xff;
 #else
 		guint32 argb = pixbuf_average_value (pixbuf);
 		guchar a = (argb >> 24) & 0xff;

--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -2718,9 +2718,15 @@ create_gradient (const GdkColor *primary,
 	for (i = 0; i < n_pixels; ++i) {
 		double ratio = (i + 0.5) / n_pixels;
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+		result[3 * i + 0] = (guchar) ((primary->red * (1 - ratio) + secondary->red * ratio) * 0x100);
+		result[3 * i + 1] = (guchar) ((primary->green * (1 - ratio) + secondary->green * ratio) * 0x100);
+		result[3 * i + 2] = (guchar) ((primary->blue * (1 - ratio) + secondary->blue * ratio) * 0x100);
+#else
 		result[3 * i + 0] = ((guint16) (primary->red * (1 - ratio) + secondary->red * ratio)) >> 8;
 		result[3 * i + 1] = ((guint16) (primary->green * (1 - ratio) + secondary->green * ratio)) >> 8;
 		result[3 * i + 2] = ((guint16) (primary->blue * (1 - ratio) + secondary->blue * ratio)) >> 8;
+#endif
 	}
 
 	return result;

--- a/libmate-desktop/mate-bg.h
+++ b/libmate-desktop/mate-bg.h
@@ -102,8 +102,13 @@ void             mate_bg_set_placement         (MateBG               *bg,
 						 MateBGPlacement       placement);
 void             mate_bg_set_color             (MateBG               *bg,
 						 MateBGColorType       type,
+#if GTK_CHECK_VERSION(3, 0, 0)
+						 GdkRGBA              *primary,
+						 GdkRGBA              *secondary);
+#else
 						 GdkColor              *primary,
 						 GdkColor              *secondary);
+#endif
 void		 mate_bg_set_draw_background   (MateBG		     *bg,
 						gboolean	      draw_background);
 /* Getters */
@@ -111,8 +116,13 @@ gboolean	 mate_bg_get_draw_background   (MateBG		     *bg);
 MateBGPlacement  mate_bg_get_placement         (MateBG               *bg);
 void		 mate_bg_get_color             (MateBG               *bg,
 						 MateBGColorType      *type,
+#if GTK_CHECK_VERSION(3, 0, 0)
+						 GdkRGBA              *primary,
+						 GdkRGBA              *secondary);
+#else
 						 GdkColor              *primary,
 						 GdkColor              *secondary);
+#endif
 const gchar *    mate_bg_get_filename          (MateBG               *bg);
 
 /* Drawing and thumbnailing */


### PR DESCRIPTION
For this change there is some more work in other packages needed.
```
[rave@mother github-matedesktop]$ grep -nr libmate-desktop/mate-bg *
caja/libcaja-private/caja-directory-background.c:42:#include <libmate-desktop/mate-bg.h>
caja/src/caja-application.c:78:#include <libmate-desktop/mate-bg.h>
caja/eel/eel-background.c:43:#include <libmate-desktop/mate-bg.h>
caja/eel/eel-background.h:51:#include <libmate-desktop/mate-bg.h>
mate-control-center/capplets/appearance/mate-wp-item.h:26:#include <libmate-desktop/mate-bg.h>
mate-control-center/capplets/appearance/appearance-desktop.c:31:#include <libmate-desktop/mate-bg.h>
mate-panel/mate-panel/panel-background-monitor.c:36:#include <libmate-desktop/mate-bg.h>
mate-screensaver/src/gs-manager.c:32:#include <libmate-desktop/mate-bg.h>
mate-settings-daemon/plugins/background/msd-background-manager.c:43:#include <libmate-desktop/mate-bg.h>
```
But this is the initial change and mainly discussions should be done here.
Note, for testing you need also apply the  https://github.com/mate-desktop/caja/tree/dev-style-context branch, otherwise you will get the caja spanning window issue until you disable 'show desktop icons'.
This means we need to push this all together.
@monsta @dnk @flexiondotorg @lukefromdc @XRevan86
Review, testing and help is appreciated

Thanks to @XRevan86 who did help me already
