### PR TITLE
GTK+-2: fix fontcolor for dark bg in caja

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -1327,9 +1327,15 @@ mate_bg_is_dark (MateBG *bg,
 		g_object_unref (pixbuf);
 	}
 
+#if GTK_CHECK_VERSION (3, 0, 0)
 	intensity = ((guint) (color.red * 65535) * 77 +
 		     (guint) (color.green * 65535) * 150 +
 		     (guint) (color.blue * 65535) * 28) >> 16;
+#else
+	intensity = (color.red * 77 +
+		     color.green * 150 +
+		     color.blue * 28) >> 16;
+#endif
 
 	return intensity < 160; /* biased slightly to be dark */
 }


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/mate-desktop/issues/237
Another gtk2 regression with caja.
This fixes the issue for me with using a dark gtk theme and setting a dark bg via 'Emplems and Backgrounds'.
Tested on top of 1.16, hope we don't get any fallout in other places.
@monsta 
Please test