### PR TITLE
Fixes for background drawing

### DIFF
--- a/libmate-desktop/mate-bg-crossfade.c
+++ b/libmate-desktop/mate-bg-crossfade.c
@@ -382,6 +382,20 @@ animations_are_disabled (MateBGCrossfade *fade)
 }
 
 static void
+send_root_property_change_notification (MateBGCrossfade *fade)
+{
+        long zero_length_pixmap = 0;
+
+        /* We do a zero length append to force a change notification,
+         * without changing the value */
+        XChangeProperty (GDK_WINDOW_XDISPLAY (fade->priv->window),
+                         GDK_WINDOW_XID (fade->priv->window),
+                         gdk_x11_get_xatom_by_name ("_XROOTPMAP_ID"),
+                         XA_PIXMAP, 32, PropModeAppend,
+                         (unsigned char *) &zero_length_pixmap, 0);
+}
+
+static void
 draw_background (MateBGCrossfade *fade)
 {
 	if (gdk_window_get_window_type (fade->priv->window) == GDK_WINDOW_ROOT) {
@@ -391,6 +405,7 @@ draw_background (MateBGCrossfade *fade)
 			    gdk_window_get_width (fade->priv->window),
 			    gdk_window_get_height (fade->priv->window),
 			    False);
+		send_root_property_change_notification (fade);
 		gdk_flush ();
 	} else {
 		gdk_window_invalidate_rect (fade->priv->window, NULL, FALSE);

--- a/libmate-desktop/mate-bg-crossfade.h
+++ b/libmate-desktop/mate-bg-crossfade.h
@@ -69,7 +69,9 @@ gboolean          mate_bg_crossfade_set_end_surface (MateBGCrossfade *fade,
 						     cairo_surface_t *surface);
 
 void              mate_bg_crossfade_start (MateBGCrossfade *fade,
-                                            GdkWindow        *window);
+                                           GdkWindow        *window);
+void              mate_bg_crossfade_start_widget (MateBGCrossfade *fade,
+                                                  GtkWidget       *widget);
 gboolean          mate_bg_crossfade_is_started (MateBGCrossfade *fade);
 void              mate_bg_crossfade_stop (MateBGCrossfade *fade);
 


### PR DESCRIPTION
This fixes directory background drawing in #506, fixes compiz-reloaded/compiz#40 (desktop background issues with Compiz 0.8.x) and fixes background fading.
Caja now draws the desktop background again and the gap in code between GTK+ 3.22 and previous versions is removed.
Other parts of the change: mate-desktop/caja#731, mate-desktop/mate-settings-daemon#169.