### PR TITLE
Correct little imprecision in man mate-about

### DIFF
--- a/man/mate-about.1
+++ b/man/mate-about.1
@@ -6,7 +6,7 @@
 .SH NAME
 mate-about \- Learn more about MATE
 .SH SYNOPSIS
-.B mate-about [\-\-mate-version]
+.B mate-about [\-\-version]
 .SH DESCRIPTION
 The \fImate-about\fP program is a tool to learn more about MATE and
 who creates MATE. It contains an introduction about the project, and
@@ -17,7 +17,7 @@ MATE Foundation members.
 .SH OPTIONS
 The following options are supported:
 .TP
-.I "--mate-version"
+.I "--version"
 Output the MATE version instead of running a graphical interface.
 .SH BUGS
 If you find bugs in the \fImate-about\fP program, please report


### PR DESCRIPTION
The command mate-about doesn't recognize the option --mate-version, it works with --version