### PR TITLE
gtk show uri deprecations

### DIFF
--- a/libmate-desktop/mate-aboutdialog.c
+++ b/libmate-desktop/mate-aboutdialog.c
@@ -162,12 +162,18 @@ default_url_hook (MateAboutDialog *about,
                   const gchar    *uri,
                   gpointer        user_data)
 {
+#if GTK_CHECK_VERSION (3, 22, 0)
+  GError *error = NULL;
+
+  if (!gtk_show_uri_on_window (GTK_WINDOW (about), uri, gtk_get_current_event_time (), &error))
+#else
   GdkScreen *screen;
   GError *error = NULL;
 
   screen = gtk_widget_get_screen (GTK_WIDGET (about));
 
   if (!gtk_show_uri (screen, uri, gtk_get_current_event_time (), &error))
+#endif
     {
       GtkWidget *dialog;
 

--- a/libmate-desktop/mate-desktop-item.c
+++ b/libmate-desktop/mate-desktop-item.c
@@ -2080,10 +2080,17 @@ mate_desktop_item_launch_on_screen_with_env (
 			return -1;
 		}
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+		retval = gtk_show_uri_on_window  (NULL,
+		                                  url,
+		                                  GDK_CURRENT_TIME,
+		                                  error);
+#else
 		retval = gtk_show_uri  (screen,
 					url,
 					GDK_CURRENT_TIME,
 					error);
+#endif
 		return retval ? 0 : -1;
 	}
 


### PR DESCRIPTION
Please test.
The change in mate-aboutdialog.c can't be tested any more as all MATE applications use gtk_about now.
We need to remove that lib, before someone other starts to fix more deprecations here ;)
@monsta thoughts ?

Honestly, i have no idea where/for what mate-desktop-item.c is used and how we can test this uri change. Any ways, using *NULL* here should be save.


