### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -858,7 +858,11 @@ draw_color_each_monitor (MateBG    *bg,
 	num_monitors = gdk_screen_get_n_monitors (screen);
 #endif
 	for (monitor = 0; monitor < num_monitors; monitor++) {
+#if GTK_CHECK_VERSION (3, 22, 0)
+		gdk_monitor_get_geometry (gdk_display_get_monitor (display, monitor), &rect);
+#else
 		gdk_screen_get_monitor_geometry (screen, monitor, &rect);
+#endif
 		draw_color_area (bg, dest, &rect);
 	}
 }
@@ -1043,7 +1047,11 @@ draw_each_monitor (MateBG    *bg,
 		GdkRectangle rect;
 		GdkPixbuf *pixbuf;
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+		gdk_monitor_get_geometry (gdk_display_get_monitor (display, monitor), &rect);
+#else
 		gdk_screen_get_monitor_geometry (screen, monitor, &rect);
+#endif
 
 		pixbuf = get_pixbuf_for_size (bg, monitor, rect.width, rect.height);
 		if (pixbuf) {

--- a/libmate-desktop/mate-rr-labeler.c
+++ b/libmate-desktop/mate-rr-labeler.c
@@ -364,13 +364,22 @@ position_window (MateRRLabeler  *labeler,
 {
 	GdkRectangle    workarea;
 	GdkRectangle    monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor     *monitor_num;
+#else
 	int             monitor_num;
+#endif
 
 	get_work_area (labeler, &workarea);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	monitor_num = gdk_display_get_monitor_at_point (gdk_screen_get_display (labeler->priv->screen), x, y);
+	gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
 	monitor_num = gdk_screen_get_monitor_at_point (labeler->priv->screen, x, y);
 	gdk_screen_get_monitor_geometry (labeler->priv->screen,
                                          monitor_num,
                                          &monitor);
+#endif
 	gdk_rectangle_intersect (&monitor, &workarea, &workarea);
 
 	gtk_window_move (GTK_WINDOW (window), workarea.x, workarea.y);


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_point