### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -1471,8 +1471,8 @@ mate_bg_get_surface_from_root (GdkScreen *screen)
 		gdk_error_trap_pop_ignored ();
 	}
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &width, &height);
+	width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 	if (source_pixmap) {
 		surface = cairo_surface_create_similar (source_pixmap,
@@ -2117,14 +2117,10 @@ scale_thumbnail (MateBGPlacement placement,
 	if (get_thumb_annotations (thumb, &o_width, &o_height)		||
 	    (filename && get_original_size (filename, &o_width, &o_height))) {
 
-		int scr_height;
-		int scr_width;
+		int scr_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
+		int scr_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
 		int thumb_width = gdk_pixbuf_get_width (thumb);
 		int thumb_height = gdk_pixbuf_get_height (thumb);
-
-		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-					 &scr_width, &scr_height);
-
 		double screen_to_dest = fit_factor (scr_width, scr_height,
 						    dest_width, dest_height);
 		double thumb_to_orig  = fit_factor (thumb_width, thumb_height,

--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -30,6 +30,7 @@
 #include <math.h>
 #include <string.h>
 
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n-lib.h>
@@ -1306,7 +1307,6 @@ popup_position_func (GtkMenu   *menu,
   GtkRequisition req;      
   gint root_x, root_y;
   GdkScreen *screen;
-  gint sc_width, sc_height;
   GtkAllocation allocation;
   
   widget = GTK_WIDGET (user_data);
@@ -1324,12 +1324,8 @@ popup_position_func (GtkMenu   *menu,
 
   /* Ensure sanity */
   screen = gtk_widget_get_screen (widget);
-
-  gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                           &sc_width, &sc_height);
-
-  *x = CLAMP (*x, 0, MAX (0, sc_width - req.width));
-  *y = CLAMP (*y, 0, MAX (0, sc_height - req.height));
+  *x = CLAMP (*x, 0, MAX (0, WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) - req.width));
+  *y = CLAMP (*y, 0, MAX (0, HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) - req.height));
 }
 
 static void

--- a/libmate-desktop/mate-rr-labeler.c
+++ b/libmate-desktop/mate-rr-labeler.c
@@ -121,9 +121,8 @@ get_work_area (MateRRLabeler *labeler,
 	/* Defaults in case of error */
 	rect->x = 0;
 	rect->y = 0;
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (labeler->priv->screen), NULL, NULL,
-				 &rect->width, &rect->height);
+	rect->width = WidthOfScreen (gdk_x11_screen_get_xscreen (labeler->priv->screen));
+	rect->height = HeightOfScreen (gdk_x11_screen_get_xscreen (labeler->priv->screen));
 
 	if (workarea == None)
 		return FALSE;


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-desktop/commit/6137212bce120c9eb5555ae777fc7fea2f71e43e

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height