### PR TITLE
drop non-working can-change-accels option from GSettings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+### mate-desktop 1.19.3
+
 ### mate-desktop 1.19.2
 
   * Translations update

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([mate_platform], [1])
 m4_define([mate_minor], [19])
-m4_define([mate_micro], [2])
+m4_define([mate_micro], [3])
 
 m4_define(mate_version, [mate_platform.mate_minor.mate_micro]),
 

--- a/schemas/org.mate.interface.gschema.xml.in
+++ b/schemas/org.mate.interface.gschema.xml.in
@@ -15,11 +15,6 @@
       <summary>Menus Have Tearoff</summary>
       <description>Whether menus should have a tearoff.</description>
     </key>
-    <key name="can-change-accels" type="b">
-      <default>false</default>
-      <summary>Can Change Accels</summary>
-      <description>Whether the user can dynamically type a new accelerator when  positioned over an active menuitem.</description>
-    </key>
     <key name="toolbar-style" type="s">
       <default>'both-horiz'</default>
       <summary>Toolbar Style</summary>


### PR DESCRIPTION
it doesn't work with GTK+3, see https://github.com/mate-desktop/atril/issues/247, https://github.com/mate-desktop/mate-calc/issues/30, https://github.com/mate-desktop/mate-desktop/issues/296

this PR bumps version so that m-s-d can rely on it