### PR TITLE
mate-rr-labeler: fix font-color for dark themes

### DIFF
--- a/libmate-desktop/mate-rr-labeler.c
+++ b/libmate-desktop/mate-rr-labeler.c
@@ -380,7 +380,7 @@ create_label_window (MateRRLabeler *labeler, MateRROutputInfo *output, GdkRGBA *
 	GtkWidget *widget;
 	char *str;
 	char *display_name;
-	GdkColor black = { 0, 0, 0, 0 };
+	GdkRGBA black = { 0, 0, 0, 1.0 };
 	int x,y;
 
 	window = gtk_window_new (GTK_WINDOW_POPUP);
@@ -421,7 +421,7 @@ create_label_window (MateRRLabeler *labeler, MateRROutputInfo *output, GdkRGBA *
 	 * theme's colors, since the label is always shown against a light
 	 * pastel background.  See bgo#556050
 	 */
-	gtk_widget_modify_fg (widget, gtk_widget_get_state_flags (widget), &black);
+	gtk_widget_override_color (widget, gtk_widget_get_state_flags (widget), &black);
 
 	gtk_container_add (GTK_CONTAINER (window), widget);
 
@@ -519,7 +519,7 @@ mate_rr_labeler_hide (MateRRLabeler *labeler)
  * mate_rr_labeler_get_rgba_for_output:
  * @labeler: A #MateRRLabeler
  * @output: Output device (i.e. monitor) to query
- * @rgba_out: (out): Color of selected monitor.
+ * @color_out: (out): Color of selected monitor.
  *
  * Get the color used for the label on a given output (monitor).
  */


### PR DESCRIPTION
Fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/29

This fixes wrong font-color for monitor info popup for all dark themes.
Issue was caused by a last missing port to GdkRGBA color.

Note:
....i know that gtk_widget_override_color {} is deprecated too, but i don't know how to replace it. 