### PR TITLE
Support background fallback on HiDPI

### DIFF
--- a/libmate-desktop/mate-bg.h
+++ b/libmate-desktop/mate-bg.h
@@ -127,6 +127,13 @@ cairo_surface_t *mate_bg_create_surface        (MateBG               *bg,
 						int                   height,
 						gboolean              root);
 
+cairo_surface_t *mate_bg_create_surface_scale  (MateBG               *bg,
+						GdkWindow            *window,
+						int                   width,
+						int                   height,
+						int                   scale,
+						gboolean              root);
+
 gboolean         mate_bg_get_image_size        (MateBG               *bg,
 						 MateDesktopThumbnailFactory *factory,
                                                  int                    best_width,


### PR DESCRIPTION
This change is a super hacky way of supporting the fallback desktop background (without caja) on HiDPI displays. It does this by doing two things: providing a function for scaled-up background surfaces using cairo_scale; and triggering a change signal when the entire background schema is re-loaded, and so triggering a redraw.