### PR TITLE
Change default cursor-size to 24px

### DIFF
--- a/schemas/org.mate.peripherals-mouse.gschema.xml.in
+++ b/schemas/org.mate.peripherals-mouse.gschema.xml.in
@@ -41,7 +41,7 @@
       <description>Cursor theme name.</description>
     </key>
     <key name="cursor-size" type="i">
-      <default>18</default>
+      <default>24</default>
       <summary>Cursor size</summary>
       <description>Size of the cursor referenced by cursor_theme.</description>
     </key>


### PR DESCRIPTION
The MATE cursor theme does not have an 18px cursor size, so having
a 18px as the default setting does not make sense. Using 24px looks
better in modern displays and allows for proper HiDPI scaling.

Relevant: mate-desktop/mate-control-center/pull/342