### PR TITLE
Add toggle for synchronizing QT_SCALE_FACTOR to GDK_SCALE_FACTOR

### DIFF
--- a/schemas/org.mate.interface.gschema.xml.in
+++ b/schemas/org.mate.interface.gschema.xml.in
@@ -174,7 +174,12 @@
       <default>0</default>
       <range min="0" max="2"/>
       <summary>Window Scaling Factor</summary>
-      <description>Internal scale factor that maps from window coordinates to the actual device pixels. On traditional systems this is 1, but on very high density displays (e.g. HiDPI, Retina) this can be a higher value (often 2). Set to 0 to auto-detect.</description>
+      <description>This controls the GTK scale factor that maps from window coordinates to the actual device pixels. On traditional systems this is 1, but on very high density displays (e.g. HiDPI, Retina) this can be a higher value (often 2). Set to 0 to auto-detect.</description>
+    </key>
+    <key name="window-scaling-factor-qt-sync" type="b">
+      <default>true</default>
+      <summary>Scaling Factor for QT appllications</summary>
+      <description>This setting determines whether MATE controls the scale factor for QT applications. Enable to synchronize with the GTK scale factor when initializing the session, disable to control this value elsewhere. Requires restarting your session.</description>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
When enabled (default), m-s-d will attempt to set QT_SCALE_FACTOR during the init phase.
When disabled, the user can then choose to control this env var elsewhere.

* Requires mate-desktop/mate-settings-daemon/pull/225
* Fixes mate-desktop/mate-session-manager/issues/158