### PR TITLE
interface: add key to enable/disable primary paste from middlemouse

### DIFF
--- a/schemas/org.mate.interface.gschema.xml.in
+++ b/schemas/org.mate.interface.gschema.xml.in
@@ -181,5 +181,12 @@
       <summary>Scaling Factor for QT appllications</summary>
       <description>This setting determines whether MATE controls the scale factor for QT applications. Enable to synchronize with the GTK scale factor when initializing the session, disable to control this value elsewhere. Requires restarting your session.</description>
     </key>
+    <key name="gtk-enable-primary-paste" type="b">
+      <default>true</default>
+      <summary>Enable the primary paste selection</summary>
+      <description>
+        If true, gtk+ uses the primary paste selection, usually triggered by a middle mouse button click.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Needed for https://github.com/mate-desktop/mate-settings-daemon/pull/234   Default is "enabled" to avoid any change in expected behavior with a default install.