### PR TITLE
Add new setting to control XKB modifier latching

### DIFF
--- a/schemas/org.mate.accessibility-keyboard.gschema.xml.in
+++ b/schemas/org.mate.accessibility-keyboard.gschema.xml.in
@@ -61,6 +61,10 @@
     <key name="stickykeys-enable" type="b">
       <default>false</default>
     </key>
+    <key name="stickykeys-latch-to-lock" type="b">
+      <default>true</default>
+      <description>Latch modifiers when pressed twice in a row until the same modifier is pressed again.</description>
+    </key>
     <key name="stickykeys-two-key-off" type="b">
       <default>false</default>
       <description>Disable if two keys are pressed at the same time.</description>


### PR DESCRIPTION
Add new setting *org.mate.accessibility-keyboard.stickykeys-latch-to-lock* to control whether latching is enabled together with sticky keys.

Default value is for compatibility with current behavior, although I'd rather see that disabled by default as it is fairly confusing for the newcomer.

See https://github.com/mate-desktop/mate-settings-daemon/pull/237 and https://github.com/mate-desktop/mate-control-center/pull/374.