### PR TITLE
avoid redefined warning of MATE_DESKTOP_USE_UNSTABLE_API

### DIFF
--- a/libmate-desktop/mate-bg-crossfade.c
+++ b/libmate-desktop/mate-bg-crossfade.c
@@ -34,7 +34,10 @@
 #include <cairo.h>
 #include <cairo-xlib.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #include <mate-bg.h>
 #include "mate-bg-crossfade.h"
 

--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -43,7 +43,10 @@ Authors: Soren Sandmann <sandmann@redhat.com>
 
 #include <cairo.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #include <mate-bg.h>
 #include <mate-bg-crossfade.h>
 

--- a/libmate-desktop/mate-desktop-item.c
+++ b/libmate-desktop/mate-desktop-item.c
@@ -54,7 +54,10 @@
 
 #define sure_string(s) ((s)!=NULL?(s):"")
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #undef MATE_DISABLE_DEPRECATED
 #include <mate-desktop-item.h>
 #include <mate-desktop-utils.h>

--- a/libmate-desktop/mate-desktop-thumbnail.c
+++ b/libmate-desktop/mate-desktop-thumbnail.c
@@ -40,7 +40,10 @@
 #define GDK_PIXBUF_ENABLE_BACKEND
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #include "mate-desktop-thumbnail.h"
 #include <glib/gstdio.h>
 #include <glib-unix.h>

--- a/libmate-desktop/mate-desktop-utils.c
+++ b/libmate-desktop/mate-desktop-utils.c
@@ -31,7 +31,9 @@
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
 #include <mate-desktop-utils.h>
 
 #include "private.h"

--- a/libmate-desktop/mate-languages.c
+++ b/libmate-desktop/mate-languages.c
@@ -36,7 +36,10 @@
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #include "mate-languages.h"
 
 #include <langinfo.h>

--- a/libmate-desktop/mate-rr-config.c
+++ b/libmate-desktop/mate-rr-config.c
@@ -24,7 +24,9 @@
  * Author: Soren Sandmann <sandmann@redhat.com>
  */
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
 
 #include <config.h>
 #include <glib/gi18n-lib.h>

--- a/libmate-desktop/mate-rr-labeler.c
+++ b/libmate-desktop/mate-rr-labeler.c
@@ -25,7 +25,9 @@
  * Author: Federico Mena-Quintero <federico@novell.com>
  */
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
 
 #include <config.h>
 #include <glib/gi18n-lib.h>

--- a/libmate-desktop/mate-rr-output-info.c
+++ b/libmate-desktop/mate-rr-output-info.c
@@ -21,7 +21,9 @@
  * Boston, MA 02111-1307, USA.
  */
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
 
 #include <config.h>
 

--- a/libmate-desktop/mate-rr.c
+++ b/libmate-desktop/mate-rr.c
@@ -22,7 +22,9 @@
  * Author: Soren Sandmann <sandmann@redhat.com>
  */
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
 
 #include <config.h>
 #include <glib/gi18n-lib.h>

--- a/libmate-desktop/mate-thumbnail-pixbuf-utils.c
+++ b/libmate-desktop/mate-thumbnail-pixbuf-utils.c
@@ -29,7 +29,10 @@
 #include <string.h>
 #include <glib.h>
 
+#ifndef MATE_DESKTOP_USE_UNSTABLE_API
 #define MATE_DESKTOP_USE_UNSTABLE_API
+#endif
+
 #include "mate-desktop-thumbnail.h"
 
 #define LOAD_BUFFER_SIZE 65536


### PR DESCRIPTION
It show redefined warning  when build use meson, so change the code.