### PR TITLE
schemas: Define schema for a default calculator

### DIFF
--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -4,6 +4,7 @@ desktop_gschemas_in = \
 	org.mate.applications-at-mobility.gschema.xml.in \
 	org.mate.applications-at-visual.gschema.xml.in \
 	org.mate.applications-browser.gschema.xml.in \
+	org.mate.applications-calculator.gschema.xml.in \
 	org.mate.applications-office.gschema.xml.in \
 	org.mate.applications-terminal.gschema.xml.in \
 	org.mate.background.gschema.xml.in \

--- a/schemas/org.mate.applications-calculator.gschema.xml.in
+++ b/schemas/org.mate.applications-calculator.gschema.xml.in
@@ -1,0 +1,9 @@
+<schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <schema id="org.mate.applications-calculator" path="/org/mate/desktop/applications/calculator/">
+    <key name="exec" type="s">
+      <default>'mate-calc'</default>
+      <summary>Calculator application</summary>
+      <description>Calculator program to use when starting applications that require one.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
• Defines a schema that allows users to specify a default calculator application.
• Default initialized to 'galculator'.
• By itself, this PR does not change much. However, it allows for other relevant PRs to act on the existence of this schema.
• Will open PR at https://github.com/mate-desktop/mate-control-center to open a PR to control the schema
• Will open PR at https://github.com/mate-desktop/mate-settings-daemon to update https://github.com/mate-desktop/mate-settings-daemon/blob/master/plugins/media-keys/msd-media-keys-manager.c to honor the schema as opposed to the following behavior:
1. Execute 'galculator', if available.
2. If 'galculator' is not available, execute 'mate-calc', if available.
3. If 'mate-calc' is not available, execute 'gnome-calculator', if available.
4. If 'gnome-calculator' is not available, silently do nothing.