### PR TITLE
mate-hsv: avoid duplicate initialization in variable

### DIFF
--- a/libmate-desktop/mate-hsv.c
+++ b/libmate-desktop/mate-hsv.c
@@ -928,7 +928,6 @@ paint_triangle (MateHSV  *hsv,
   int width, height;
   GtkStyleContext *context;
 
-  priv = hsv->priv;
   width = gtk_widget_get_allocated_width (widget); 
   height = gtk_widget_get_allocated_height (widget); 
   /* Compute triangle's vertices */


### PR DESCRIPTION
```
mate-hsv.c:913:19: warning: Value stored to 'priv' during its initialization is never read
  MateHSVPrivate *priv = hsv->priv;
                  ^~~~   ~~~~~~~~~
```