### PR TITLE
[Security] test-ditem: Use 'g_strlcat' instead of 'strcat'

### DIFF
--- a/libmate-desktop/test-ditem.c
+++ b/libmate-desktop/test-ditem.c
@@ -91,7 +91,7 @@ test_ditem (const char *file)
 		 "Neu gesetzt!");
 
 	getcwd (path, 255 - strlen ("/foo.desktop"));
-	strcat (path, "/foo.desktop");
+	g_strlcat (path, "/foo.desktop", sizeof (path));
 
 	g_print ("Saving to foo.desktop\n");
 	uri = g_filename_to_uri (path, NULL, NULL);


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
test-ditem.c:94:2: warning: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119
        strcat (path, "/foo.desktop");
        ^~~~~~
```