### PR TITLE
[Security] Use 'g_strlcpy' instead of 'strcpy'

### DIFF
--- a/libmate-desktop/mate-desktop-item.c
+++ b/libmate-desktop/mate-desktop-item.c
@@ -2115,7 +2115,7 @@ mate_desktop_item_launch_on_screen_with_env (
 
 	/* make a new copy and get rid of spaces */
 	the_exec = g_alloca (strlen (exec) + 1);
-	strcpy (the_exec, exec);
+	g_strlcpy (the_exec, exec, strlen (exec) + 1);
 
 	if ( ! strip_the_amp (the_exec)) {
 		g_set_error (error,

--- a/libmate-desktop/mate-rr-config.c
+++ b/libmate-desktop/mate-rr-config.c
@@ -546,7 +546,7 @@ mate_rr_config_load_current (MateRRConfig *config, GError **error)
 	    }
 	    else
 	    {
-		strcpy (output->priv->vendor, "???");
+		g_strlcpy (output->priv->vendor, "???", sizeof (output->priv->vendor));
 		output->priv->product = 0;
 		output->priv->serial = 0;
 	    }


### PR DESCRIPTION
Fixes Clang static analyzer warnings:

```
mate-rr-config.c:549:3: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
                strcpy (output->priv->vendor, "???");
                ^~~~~~

mate-desktop-item.c:2118:2: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
        strcpy (the_exec, exec);
        ^~~~~~
```