### PR TITLE
mate-desktop-thumbnail: avoid 'NULL' parameter

### DIFF
--- a/libmate-desktop/mate-desktop-thumbnail.c
+++ b/libmate-desktop/mate-desktop-thumbnail.c
@@ -1074,7 +1074,7 @@ mate_desktop_thumbnail_factory_can_thumbnail (MateDesktopThumbnailFactory *facto
     }
   g_mutex_unlock (&factory->priv->lock);
 
-  if (have_script || mimetype_supported_by_gdk_pixbuf (mime_type))
+  if (uri && (have_script || mimetype_supported_by_gdk_pixbuf (mime_type)))
     {
       return !mate_desktop_thumbnail_factory_has_valid_failed_thumbnail (factory,
                                                                           uri,


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
mate-desktop-thumbnail.c:933:54: warning: Null pointer passed as an argument to a 'nonnull' parameter
  g_checksum_update (checksum, (const guchar *) uri, strlen (uri));
                                                     ^~~~~~~~~~~~
```

This function is used in `caja` and `eom`:

![2019-03-18_11-43](https://user-images.githubusercontent.com/7734191/54525189-ea26f880-4973-11e9-8ac6-8f280303a54e.png)