### PR TITLE
build: use localedir instead of DATADIRNAME

### DIFF
--- a/libmate-desktop/Makefile.am
+++ b/libmate-desktop/Makefile.am
@@ -24,7 +24,7 @@ AM_CPPFLAGS =							\
 	$(XLIB_CFLAGS)						\
 	$(DCONF_CFLAGS)						\
 	-DG_LOG_DOMAIN=\"MateDesktop\"				\
-	-DMATELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale\""	\
+	-DMATELOCALEDIR=\""$(localedir)\""			\
 	-DPNP_IDS=\""$(PNP_IDS)"\"				\
 	-DISO_CODES_PREFIX=\""$(ISO_CODES_PREFIX)"\"		\
 	$(DISABLE_DEPRECATED_CFLAGS)


### PR DESCRIPTION
Fixes https://github.com/zhuyaliang/user-admin/issues/21

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>