### PR TITLE
Travis CI: Fix icon name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,7 +188,7 @@ after_scripts:
   -     if [ ${DISTRO_NAME} == "fedora" ];then
   -         cppcheck --xml --output-file=cppcheck.xml --enable=warning,style,performance,portability,information,missingInclude .
   -         cppcheck-htmlreport --title=${REPO_NAME} --file=cppcheck.xml --report-dir=cppcheck-htmlreport
-  -         ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/${REPO_NAME}/raw/master/icons/hicolor_apps_16x16_mate.png
+  -         ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/${REPO_NAME}/raw/master/icons/16x16/apps/mate-desktop.png
   -     fi
   -     make distcheck
   - fi


### PR DESCRIPTION
the icon name was changed since the commit:
https://github.com/mate-desktop/mate-desktop/commit/d83bccb64d612034be471c0724edd129519c3584

and it was moved with the commit:
https://github.com/mate-desktop/mate-desktop/commit/6109546780fde4bc8e9986c3f258960a5fdd76bf

https://mate-desktop.mate-desktop.dev

before:

![2019-06-01_20-22](https://user-images.githubusercontent.com/7734191/58752462-60d18d80-84af-11e9-9561-60a52860f95f.png)

later:

![2019-06-01_20-52](https://user-images.githubusercontent.com/7734191/58752463-65964180-84af-11e9-9aa9-d3de1fc15612.png)