### PR TITLE
configure: drop check for itstool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,7 +203,6 @@ GETTEXT_PACKAGE=mate-desktop
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
 		   [The gettext translation domain])
 AC_SUBST(GETTEXT_PACKAGE)
-AC_PATH_PROG([ITSTOOL], [itstool], [notfound])
 
 GLIB_GSETTINGS
 


### PR DESCRIPTION
I think this can be dropped because help is in mate-user-guide.
This was added and already mentioned here.
https://github.com/mate-desktop/mate-desktop/pull/376#pullrequestreview-242001373
Please review.