### PR TITLE
schemas: Define schema for a default messenger

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,6 +22,7 @@ schemas/org.mate.applications-at-mobility.gschema.xml
 schemas/org.mate.applications-at-visual.gschema.xml
 schemas/org.mate.applications-browser.gschema.xml
 schemas/org.mate.applications-calculator.gschema.xml
+schemas/org.mate.applications-messenger.gschema.xml 
 schemas/org.mate.applications-office.gschema.xml
 schemas/org.mate.applications-terminal.gschema.xml
 schemas/org.mate.background.gschema.xml.in

--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -5,6 +5,7 @@ gsettings_SCHEMAS = \
 	org.mate.applications-at-visual.gschema.xml \
 	org.mate.applications-browser.gschema.xml \
 	org.mate.applications-calculator.gschema.xml \
+	org.mate.applications-messenger.gschema.xml \
 	org.mate.applications-office.gschema.xml \
 	org.mate.applications-terminal.gschema.xml \
 	org.mate.background.gschema.xml \

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -22,6 +22,7 @@ schemas += [
   'org.mate.applications-at-visual.gschema.xml',
   'org.mate.applications-browser.gschema.xml',
   'org.mate.applications-calculator.gschema.xml',
+  'org.mate.applications-messenger.gschema.xml',
   'org.mate.applications-office.gschema.xml',
   'org.mate.applications-terminal.gschema.xml',
   'org.mate.debug.gschema.xml',

--- a/schemas/org.mate.applications-messenger.gschema.xml
+++ b/schemas/org.mate.applications-messenger.gschema.xml
@@ -1,0 +1,9 @@
+<schemalist gettext-domain="mate-desktop">
+  <schema id="org.mate.applications-messenger" path="/org/mate/desktop/applications/messenger/">
+    <key name="exec" type="s">
+      <default>''</default>
+      <summary>Instant Messaging application</summary>
+      <description>Instant Messaging program to use when starting applications that require one.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
Defines a schema that allows users to specify a default instant messaging application.
Default initialized to 'pidgin'.