### PR TITLE
using autotools to generate tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,6 @@ after_scripts:
   -         ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/${REPO_NAME}/raw/master/icons/16x16/apps/mate-desktop.png
   -     fi
   -     make distcheck
-  -     tar tf mate-desktop-*.tar.xz|grep po #just for view
   - fi
 
 releases:

--- a/.travis.yml
+++ b/.travis.yml
@@ -191,16 +191,14 @@ after_scripts:
   -         ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/${REPO_NAME}/raw/master/icons/16x16/apps/mate-desktop.png
   -     fi
   -     make distcheck
-  - elif [ -d _build ];then
-  -     ninja -C _build dist
   - fi
 
 releases:
   draft: false
   prerelease: false
-  checksum: false
+  checksum: true
   file_glob: true
-  files: _build/meson-dist/mate-desktop-*.tar.xz*
+  files: mate-desktop-*.tar.xz
   github_release:
     tags: true
     overwrite: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,7 @@ build_scripts:
 #  -     bash ./fedora.sh
 #  - fi
   - ./autogen.sh
+  - sed -i 's/$(POFILES) $(GMOFILES) \\/$(POFILES) \\/' po/Makefile.in.in
   - scan-build $CHECKERS ./configure --prefix=/usr --enable-gtk-doc
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
@@ -191,6 +192,7 @@ after_scripts:
   -         ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/${REPO_NAME}/raw/master/icons/16x16/apps/mate-desktop.png
   -     fi
   -     make distcheck
+  -     tar tf mate-desktop-*.tar.xz|grep po #just for view
   - fi
 
 releases:


### PR DESCRIPTION
This is better because `ninja -C _build dist` do not create auto-generated files