### PR TITLE
make 'rsvg-convert' optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ requires:
     - gtk3
     - intltool
     - iso-codes
-    - librsvg
     - meson
     - make
     - mate-common
@@ -96,7 +95,6 @@ requires:
     - libglib2.0-doc
     - libgtk-3-dev
     - libgtk-3-doc
-    - librsvg2-bin
     - libstartup-notification0-dev
     - libx11-dev
     - libxml2-dev
@@ -118,7 +116,6 @@ requires:
     - gtk3-devel
     - iso-codes-devel
     - itstool
-    - librsvg2-tools
     - make
     - mate-common
     - meson
@@ -140,7 +137,6 @@ requires:
     - libglib2.0-doc
     - libgtk-3-dev
     - libgtk-3-doc
-    - librsvg2-bin
     - libstartup-notification0-dev
     - libx11-dev
     - libxml2-dev

--- a/configure.ac
+++ b/configure.ac
@@ -229,9 +229,7 @@ GTK_DOC_CHECK([1.4])
 
 dnl ICONS: convert svg to png
 AC_PATH_PROG(RSVG_CONVERT, rsvg-convert)
-if test x$RSVG_CONVERT = x ; then
-    AC_MSG_ERROR([could not locate rsvg-convert])
-fi
+AM_CONDITIONAL([HAVE_RSVG_CONVERT], [test "x$RSVG_CONVERT" != x])
 
 AC_CONFIG_FILES([
 Makefile

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -29,6 +29,7 @@ update-icon-cache:
 		echo "***   $(gtk_update_icon_cache)"; \
 	fi
 
+if HAVE_RSVG_CONVERT
 build-png-icons:
 	$(RSVG_CONVERT) -w 16 -h 16 scalable/apps/mate-desktop.svg -o 16x16/apps/mate-desktop.png
 	$(RSVG_CONVERT) -w 22 -h 22 scalable/apps/mate-desktop.svg -o 22x22/apps/mate-desktop.png
@@ -36,6 +37,7 @@ build-png-icons:
 	$(RSVG_CONVERT) -w 32 -h 32 scalable/apps/mate-desktop.svg -o 32x32/apps/mate-desktop.png
 	$(RSVG_CONVERT) -w 48 -h 48 scalable/apps/mate-desktop.svg -o 48x48/apps/mate-desktop.png
 	$(RSVG_CONVERT) -w 128 -h 128 scalable/apps/mate-desktop.svg -o 128x128/apps/mate-desktop.png
+endif
 
 clean-png-icons:
 	rm -f $(png_icons)


### PR DESCRIPTION
EDIT: in https://github.com/mate-desktop/mate-desktop/pull/369 the PNG icons are created if they are not present in icon folder, so, we don't need it in normal build: https://github.com/mate-desktop/mate-desktop/pull/369#issuecomment-475062827