### PR TITLE
meson: fix build version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mate-desktop',
   'c',
-  version: '1.23.1',
+  version: '1.23.2',
   license: [ 'GPL-2', 'FDL-1.1', 'LGPL-2' ],
 )
 


### PR DESCRIPTION
Bump the version in meson.build to 1.23.2 (same as in configure.ac).
Otherwise meson builds break building anything that depends on mate-desktop 1.23.2 , and mate-about displays version 1.23.1 instead of 1.23.2 in meson builds