### PR TITLE
build: introduce RELEASE_YEAR variable for mate-about dialog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,9 @@ AC_DEFINE(MATE_MAJOR, [mate_platform], [Define to the major version])
 AC_DEFINE(MATE_MINOR, [mate_minor], [Define to the minor version])
 AC_DEFINE(MATE_MICRO, [mate_micro], [Define to the micro version])
 
+RELEASE_YEAR=`date +%Y`
+AC_SUBST([RELEASE_YEAR])
+
 MATE_COMMON_INIT
 MATE_DEBUG_CHECK
 MATE_COMPILE_WARNINGS([maximum])
@@ -234,6 +237,7 @@ AM_CONDITIONAL([HAVE_RSVG_CONVERT], [test "x$RSVG_CONVERT" != x])
 AC_CONFIG_FILES([
 Makefile
 mate-about/Makefile
+mate-about/mate-about.h
 mate-about/mate-version.xml
 libmate-desktop/Makefile
 libmate-desktop/mate-desktop-2.0.pc

--- a/mate-about/Makefile.am
+++ b/mate-about/Makefile.am
@@ -19,9 +19,10 @@ versiondir = $(datadir)/mate-about
 version_DATA = mate-version.xml
 
 EXTRA_DIST = $(desktop_in_files)	\
+	     mate-about.h.in		\
 	     mate-version.xml.in
 
-CLEANFILES = $(desktop_DATA) $(bin_PROGRAMS) $(version_DATA)
+CLEANFILES = $(desktop_DATA) $(bin_PROGRAMS) $(version_DATA) mate-about.h
 
 #-include $(top_srcdir)/git.mk
 

--- a/mate-about/mate-about.h.in
+++ b/mate-about/mate-about.h.in
@@ -33,7 +33,7 @@ const char* website = "https://mate-desktop.org/";
 
 const char* copyright =  N_("Copyright © 1997-2011 GNOME developers\n"
                             "Copyright © 2011 Perberos\n"
-                            "Copyright © 2012-2019 MATE developers");
+                            "Copyright © 2012-@RELEASE_YEAR@ MATE developers");
 
 /* Increment comments_count if you add other comments. This will be
  * used to choose a random comment. */

--- a/mate-about/meson.build
+++ b/mate-about/meson.build
@@ -1,5 +1,6 @@
 date_exe = find_program('date')
 mate_date = run_command(date_exe, '+%Y-%m-%d').stdout().strip()
+mate_year = run_command(date_exe, '+%Y').stdout().strip()
 
 mate_data = configuration_data()
 
@@ -9,6 +10,9 @@ mate_data.set('MATE_DATE_COMMENT_END', '-->')
 mate_data.set('MATE_PLATFORM', mate_platform)
 mate_data.set('MATE_MINOR', mate_minor)
 mate_data.set('MATE_MICRO', mate_micro)
+
+mate_about_data = configuration_data()
+mate_about_data.set('RELEASE_YEAR', mate_year)
 
 executable('mate-about',
   'mate-about.c',
@@ -36,4 +40,11 @@ mate_version_xml_in = configure_file(
   configuration: mate_data,
   install: true,
   install_dir: join_paths(get_option('datadir'), 'mate-about'),
+)
+
+mate_about_h_in = configure_file(
+  input: 'mate-about.h.in',
+  output: 'mate-about.h',
+  configuration: mate_about_data,
+  install: false,
 )


### PR DESCRIPTION
Test 1:
```
./autogen.sh --prefix=/usr
cat mate-about/mate-about.h
make && sudo make install
```
Test 2:
```
mkdir builddir
meson setup builddir --prefix=/usr
cat builddir/mate-about/mate-about.h
sudo ninja -C builddir install
```