### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -154,9 +154,6 @@ static gboolean mate_color_selection_grab_broken (GtkWidget               *widge
 static void     mate_color_selection_set_palette_color   (MateColorSelection *colorsel,
                                                          gint               index,
                                                          GdkColor          *color);
-static void     set_focus_line_attributes               (GtkWidget         *drawing_area,
-							 cairo_t           *cr,
-							 gint              *focus_width);
 static void     default_noscreen_change_palette_func    (const GdkColor    *colors,
 							 gint               n_colors);
 static void     default_change_palette_func             (GdkScreen	   *screen,

--- a/libmate-desktop/mate-desktop-thumbnail.c
+++ b/libmate-desktop/mate-desktop-thumbnail.c
@@ -64,12 +64,10 @@ struct _MateDesktopThumbnailFactoryPrivate {
 
 static const char *appname = "mate-thumbnail-factory";
 
-static void mate_desktop_thumbnail_factory_init          (MateDesktopThumbnailFactory      *factory);
-static void mate_desktop_thumbnail_factory_class_init    (MateDesktopThumbnailFactoryClass *class);
-
 G_DEFINE_TYPE_WITH_PRIVATE (MateDesktopThumbnailFactory,
                             mate_desktop_thumbnail_factory,
                             G_TYPE_OBJECT)
+
 #define parent_class mate_desktop_thumbnail_factory_parent_class
 
 typedef struct {


### PR DESCRIPTION
Fixes the warnings:
```
mate-desktop-thumbnail.c:71:29: warning: redundant redeclaration of 'mate_desktop_thumbnail_factory_init' [-Wredundant-decls]
mate-desktop-thumbnail.c:71:29: warning: redundant redeclaration of 'mate_desktop_thumbnail_factory_class_init' [-Wredundant-decls]
mate-colorsel.c:198:14: warning: redundant redeclaration of 'set_focus_line_attributes' [-Wredundant-decls]
```