### PR TITLE
Compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,7 @@ mate-desktop $VERSION
     source code location:         ${srcdir}
     compiler:                     ${CC}
     cflags:                       ${CFLAGS}
+    warning flags:                ${WARN_CFLAGS}
     Maintainer mode:              ${USE_MAINTAINER_MODE}
     Use *_DISABLE_DEPRECATED:     ${enable_deprecation_flags}
 

--- a/mate-about/Makefile.am
+++ b/mate-about/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = mate-about
 mate_about_SOURCES = mate-about.c mate-about.h
-mate_about_CFLAGS = $(MATE_ABOUT_CFLAGS)
+mate_about_CFLAGS = $(WARN_CFLAGS) $(MATE_ABOUT_CFLAGS)
 mate_about_LDADD = $(MATE_ABOUT_LIBS)
 
 AM_CPPFLAGS = \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -9,6 +9,7 @@ mate_color_select_SOURCES = \
 
 mate_color_select_CFLAGS = \
 	-DLOCALE_DIR=\"$(datadir)/locale\" \
+	$(WARN_CFLAGS) \
 	$(MATE_DESKTOP_CFLAGS)
 
 mate_color_select_LDADD = \


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum --enable-debug
<cut>

mate-desktop 1.23.3
===================

    prefix:                       /usr/local
    exec_prefix:                  ${prefix}
    libdir:                       ${exec_prefix}/lib
    bindir:                       ${exec_prefix}/bin
    sbindir:                      ${exec_prefix}/sbin
    sysconfdir:                   ${prefix}/etc
    localstatedir:                ${prefix}/var
    datadir:                      ${datarootdir}
    source code location:         .
    compiler:                     gcc
    cflags:                        -g -O0
    warning flags:                -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare
    Maintainer mode:              yes
    Use *_DISABLE_DEPRECATED:     no

    Build mate-about:             yes
    Use external pnp.ids:         no (internal)
    Startup notification support: yes
    XRandr support:               yes
    Build introspection support:  yes
    Build gtk-doc documentation:  no

Now type `make' to compile mate-desktop
<cut>
```