### PR TITLE
mate-about: remove unused variable ‘window’

### DIFF
--- a/mate-about/mate-about.c
+++ b/mate-about/mate-about.c
@@ -32,7 +32,6 @@
 static void mate_about_on_activate(GtkApplication* app)
 {
     GList* list;
-    GtkWidget* window;
 
     list = gtk_application_get_windows(app);
 


### PR DESCRIPTION
```
mate-about.c:35:16: warning: unused variable ‘window’ [-Wunused-variable]
   35 |     GtkWidget* window;
      |                ^~~~~~
```