### PR TITLE
Make the build reproducible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,8 +45,10 @@ MATE_PLATFORM=mate_platform
 MATE_MINOR=mate_minor
 MATE_MICRO=mate_micro
 MATE_DATE=`date +"%Y-%m-%d"`
+if test "x$SOURCE_DATE_EPOCH" != "x"; then
+	MATE_DATE=`date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%d`
+fi
 
-MATE_DATE=
 MATE_DATE_COMMENT_START="<!--"
 MATE_DATE_COMMENT_END="-->"
 
@@ -62,6 +64,9 @@ AC_DEFINE(MATE_MINOR, [mate_minor], [Define to the minor version])
 AC_DEFINE(MATE_MICRO, [mate_micro], [Define to the micro version])
 
 RELEASE_YEAR=`date +%Y`
+if test "x$SOURCE_DATE_EPOCH" != "x"; then
+	RELEASE_YEAR=`date -u -d "@$SOURCE_DATE_EPOCH" +%Y`
+fi
 AC_SUBST([RELEASE_YEAR])
 
 AC_ARG_ENABLE(deprecation_flags,

--- a/mate-about/meson.build
+++ b/mate-about/meson.build
@@ -1,6 +1,11 @@
 date_exe = find_program('date')
-mate_date = run_command(date_exe, '+%Y-%m-%d').stdout().strip()
-mate_year = run_command(date_exe, '+%Y').stdout().strip()
+cmd = run_command('sh', '-c', 'echo $SOURCE_DATE_EPOCH')
+source_date_epoch = cmd.stdout().strip()
+if source_date_epoch == ''
+	source_date_epoch = run_command(date_exe, '+%s').stdout().strip()
+endif
+mate_date = run_command(date_exe, '-u', '-d', '@' + source_date_epoch, '+%Y-%m-%d').stdout().strip()
+mate_year = run_command(date_exe, '-u', '-d', '@' + source_date_epoch, '+%Y').stdout().strip()
 
 mate_data = configuration_data()
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that mate-desktop could not be built reproducibly.

This is is because it generated a "release year" based on the current build date which was embedded in the binary and possibly other files. A patch attached that uses [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) instead.

As a side-effect, this fixes the (accidental) reset of `MATE_DATE` in the Autotools build system in inherited from `mate-desktop-environment.git`.

This was originally filed in Debian as [#951357](https://bugs.debian.org/951357).