### PR TITLE
build: add meson config files to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,9 +10,15 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--enable-gtk-doc \
 	CFLAGS='-Wno-deprecated-declarations'
 
-EXTRA_DIST =			\
-	autogen.sh		\
-	COPYING-DOCS
+EXTRA_DIST = \
+	abi-check \
+	autogen.sh \
+	config.meson.h\
+	COPYING-DOCS \
+	meson.build \
+	meson_options.txt \
+	po/meson.build \
+	utils/post_install.py
 
 CLEANFILES =
 

--- a/docs/reference/mate-desktop/Makefile.am
+++ b/docs/reference/mate-desktop/Makefile.am
@@ -75,6 +75,6 @@ include $(top_srcdir)/gtk-doc.make
 
 # Other files to distribute
 # e.g. EXTRA_DIST += version.xml.in
-EXTRA_DIST += 
+EXTRA_DIST += meson.build
 
 -include $(top_srcdir)/git.mk

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -16,6 +16,9 @@ nobase_dist_icons_DATA = \
 
 gtk_update_icon_cache = gtk-update-icon-cache -f -t $(datadir)/icons/hicolor
 
+EXTRA_DIST = \
+	meson.build
+
 .PHONY: build-png-icons clean-png-icons
 
 install-data-hook: update-icon-cache

--- a/libmate-desktop/Makefile.am
+++ b/libmate-desktop/Makefile.am
@@ -137,8 +137,10 @@ CLEANFILES += $(gir_DATA) $(typelib_DATA)
 endif
 
 EXTRA_DIST = \
-	mate-desktop-2.0.pc.in                \
-	mate-desktop-2.0-uninstalled.pc.in    \
+	meson.build \
+	mate-desktop.map \
+	mate-desktop-2.0.pc.in \
+	mate-desktop-2.0-uninstalled.pc.in \
 	$(pnpdata_DATA_dist)
 
 MAINTAINERCLEANFILES = \

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -4,6 +4,9 @@ if MATE_ABOUT_ENABLED
 man_MANS += mate-about.1
 endif
 
-EXTRA_DIST = mate-about.1 mate-color-select.1
+EXTRA_DIST = \
+	meson.build \
+	mate-about.1 \
+	mate-color-select.1
 
 -include $(top_srcdir)/git.mk

--- a/mate-about/Makefile.am
+++ b/mate-about/Makefile.am
@@ -18,9 +18,11 @@ mate-about.desktop: mate-about.desktop.in
 versiondir = $(datadir)/mate-about
 version_DATA = mate-version.xml
 
-EXTRA_DIST = $(desktop_in_files)	\
-	     mate-about.h.in		\
-	     mate-version.xml.in
+EXTRA_DIST = \
+	$(desktop_in_files) \
+	meson.build \
+	mate-about.h.in \
+	mate-version.xml.in
 
 CLEANFILES = $(desktop_DATA) $(bin_PROGRAMS) $(version_DATA) mate-about.h
 

--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -21,7 +21,8 @@ gsettings_SCHEMAS = \
 @GSETTINGS_RULES@
 
 EXTRA_DIST = \
-	$(gsettings_SCHEMAS)
+	$(gsettings_SCHEMAS) \
+	meson.build
 
 CLEANFILES = \
 	*.gschema.valid

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,6 +22,8 @@ desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 mate-color-select.desktop: mate-color-select.desktop.in
 	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
-EXTRA_DIST = $(desktop_in_files)
+EXTRA_DIST = \
+	$(desktop_in_files) \
+	meson.build
 
 CLEANFILES = $(desktop_DATA) $(bin_PROGRAMS)


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-desktop/issues/431

I am not sure if adding the meson files for `po` and `utils` dir were correct.
```
EXTRA_DIST = \
	abi-check \
	autogen.sh \
	config.meson.h\
	COPYING-DOCS \
	meson.build \
	meson_options.txt \
	po/meson.build \
	utils/post_install.py
```