### PR TITLE
Remove warnings: cast between incompatible function types

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -2972,10 +2972,7 @@ slideshow_unref (SlideShow *show)
 	}
 
 	g_queue_free (show->slides);
-
-	g_list_foreach (show->stack->head, (GFunc) g_free, NULL);
-	g_queue_free (show->stack);
-
+	g_queue_free_full (show->stack, g_free);
 	g_free (show);
 }
 


### PR DESCRIPTION
```
mate-bg.c:2976:37: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 2976 |  g_list_foreach (show->stack->head, (GFunc) g_free, NULL);
      |                                     ^
--
mate-desktop-item.c:876:33: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  876 |  g_list_foreach (section->keys, (GFunc)g_free, NULL);
      |                                 ^
--
mate-desktop-item.c:900:35: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  900 |  g_list_foreach (item->languages, (GFunc)g_free, NULL);
      |                                   ^
mate-desktop-item.c:904:30: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  904 |  g_list_foreach (item->keys, (GFunc)g_free, NULL);
      |                              ^
--
mate-desktop-item.c:1564:5: warning: cast between incompatible function types from ‘void (*)(SnLauncherContext *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1564 |     (GFunc) sn_launcher_context_unref,
      |     ^
--
mate-desktop-item.c:1950:33: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1950 |   g_slist_foreach (vector_list, (GFunc)g_free, NULL);
      |                                 ^
```