### PR TITLE
Avoid use of GSettings schema for others applications

### DIFF
--- a/docs/reference/mate-desktop/mate-desktop-sections.txt
+++ b/docs/reference/mate-desktop/mate-desktop-sections.txt
@@ -22,6 +22,8 @@ mate_bg_create_thumbnail
 mate_bg_is_dark
 mate_bg_changes_with_size
 mate_bg_set_pixmap_as_root
+mate_bg_set_background_from_filename
+mate_bg_save_background_from_filename
 <SUBSECTION Private>
 mate_bg_get_type
 <SUBSECTION Standard>

--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -3280,3 +3280,33 @@ mate_bg_create_frame_thumbnail (MateBG			*bg,
 	return result;
 }
 
+/**
+ * mate_bg_set_backgroud_from_filename:
+ *
+ * Set the given filename as background
+ */
+void
+mate_bg_set_background_from_filename (MateBG			*bg,
+									 const char		*filename)
+{
+	g_return_if_fail (filename != NULL);
+
+	mate_bg_set_filename (bg, filename);
+	mate_bg_save_to_preferences (bg);
+}
+
+/**
+ * mate_bg_save_backgroud_from_filename:
+ *
+ * Save the given filename as background and draw it
+ */
+void
+mate_bg_save_background_from_filename (const char		*filename)
+{
+	MateBG	*bg;
+
+	mate_bg_load_from_preferences (bg);
+	mate_bg_set_background_from_filename (bg, filename);
+
+	g_free (bg);
+}

--- a/libmate-desktop/mate-bg.h
+++ b/libmate-desktop/mate-bg.h
@@ -167,6 +167,11 @@ MateBGCrossfade *mate_bg_set_surface_as_root_with_crossfade (GdkScreen       *sc
 							     cairo_surface_t *surface);
 cairo_surface_t *mate_bg_get_surface_from_root (GdkScreen *screen);
 
+void             mate_bg_set_background_from_filename (MateBG              *bg,
+						 const char            *filename);
+
+void             mate_bg_save_background_from_filename (const char          *filename);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
Add `void mate_bg_save_background_from_filename (const char *filename)` for avoid Gsettings use in case of future evolution for others applications, for example, caja-extensions wallpaper, Eyes of Mate or Caja...

Add too, `void mate_bg_set_background_from_filename (MateBG *bg, const char *filename)` to use with m-c-c.

Regards