### PR TITLE
mate-desktop-thumbnail: Remove trailing spaces/tabs

### DIFF
--- a/libmate-desktop/mate-desktop-thumbnail.c
+++ b/libmate-desktop/mate-desktop-thumbnail.c
@@ -585,7 +585,7 @@ mate_desktop_thumbnail_factory_finalize (GObject *object)
 {
   MateDesktopThumbnailFactory *factory;
   MateDesktopThumbnailFactoryPrivate *priv;
-  
+
   factory = MATE_DESKTOP_THUMBNAIL_FACTORY (object);
 
   priv = factory->priv;


### PR DESCRIPTION
```
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/[[:space:]]*$//' {} \;
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/\t*$//' {} \;
```