### PR TITLE
a11y-keyboard: Add capslock-beep-enable gsetting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+### mate-desktop 1.25.0
+
 ### mate-desktop 1.24.0
 
   * Translations update

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 m4_define([mate_platform], [1])
-m4_define([mate_minor], [24])
+m4_define([mate_minor], [25])
 m4_define([mate_micro], [0])
 
 m4_define(mate_version, [mate_platform.mate_minor.mate_micro]),

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mate-desktop',
   'c',
-  version: '1.24.0',
+  version: '1.25.0',
   license: [ 'GPL-2', 'FDL-1.1', 'LGPL-2' ],
 )
 

--- a/schemas/org.mate.accessibility-keyboard.gschema.xml
+++ b/schemas/org.mate.accessibility-keyboard.gschema.xml
@@ -76,5 +76,9 @@
     <key name="togglekeys-enable" type="b">
       <default>false</default>
     </key>
+    <key name="capslock-beep-enable" type="b">
+      <default>false</default>
+      <description>Beep when a key is pressed while CapsLock is active.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Add *capslock-beep-enable* gsetting, and bump the version to allow other component to require it.

Required by https://github.com/mate-desktop/mate-settings-daemon/pull/330 and https://github.com/mate-desktop/mate-control-center/pull/583.