### PR TITLE
Remove warning -Wbad-function-cast

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -2375,12 +2375,14 @@ get_pixbuf_for_size (MateBG *bg,
 
 			if (show) {
 				double alpha;
+				double timeout;
 				Slide *slide;
 
 				slideshow_ref (show);
 
 				slide = get_current_slide (show, &alpha);
-				time_until_next_change = (guint)get_slide_timeout (slide);
+				timeout = get_slide_timeout (slide);
+				time_until_next_change = (guint) timeout;
 				if (slide->fixed) {
 					FileSize *size = find_best_size (slide->file1,
 									 best_width, best_height);

--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -1250,6 +1250,7 @@ palette_set_color (GtkWidget         *drawing_area,
 		   MateColorSelection *colorsel,
 		   gdouble           *color)
 {
+  gpointer pointer;
   gdouble *new_color = g_new (double, 4);
   GdkRGBA  box_color;
 
@@ -1260,7 +1261,8 @@ palette_set_color (GtkWidget         *drawing_area,
 
   override_background_color (drawing_area, &box_color);
 
-  if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (drawing_area), "color_set")) == 0)
+  pointer = g_object_get_data (G_OBJECT (drawing_area), "color_set");
+  if (!pointer || GPOINTER_TO_INT (pointer) == 0)
     {
       static const GtkTargetEntry targets[] = {
 	{ "application/x-color", 0 }
@@ -1458,7 +1460,8 @@ palette_release (GtkWidget      *drawing_area,
       g_object_get_data (G_OBJECT (drawing_area),
 			 "gtk-colorsel-have-pointer") != NULL)
     {
-      if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (drawing_area), "color_set")) != 0)
+      gpointer pointer = g_object_get_data (G_OBJECT (drawing_area), "color_set");
+      if (pointer && GPOINTER_TO_INT (pointer) != 0)
         {
           gdouble color[4];
           palette_get_color (drawing_area, color);
@@ -1517,7 +1520,8 @@ palette_activate (GtkWidget   *widget,
       (event->keyval == GDK_KEY_KP_Enter) ||
       (event->keyval == GDK_KEY_KP_Space))
     {
-      if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (widget), "color_set")) != 0)
+      gpointer pointer = g_object_get_data (G_OBJECT (widget), "color_set");
+      if (pointer && GPOINTER_TO_INT (pointer) != 0)
         {
           gdouble color[4];
           palette_get_color (widget, color);
@@ -2127,6 +2131,9 @@ update_color (MateColorSelection *colorsel)
   gchar entryval[12];
   gchar opacity_text[32];
   gchar *ptr;
+  double r;
+  double g;
+  double b;
 
   priv->changing = TRUE;
   color_sample_update_samples (colorsel);
@@ -2160,10 +2167,10 @@ update_color (MateColorSelection *colorsel)
   g_snprintf (opacity_text, 32, "%.0f", scale_round (priv->color[COLORSEL_OPACITY], 255));
   gtk_entry_set_text (GTK_ENTRY (priv->opacity_entry), opacity_text);
 
-  g_snprintf (entryval, 11, "#%2X%2X%2X",
-	      (guint) (scale_round (priv->color[COLORSEL_RED], 255)),
-	      (guint) (scale_round (priv->color[COLORSEL_GREEN], 255)),
-	      (guint) (scale_round (priv->color[COLORSEL_BLUE], 255)));
+  r = scale_round (priv->color[COLORSEL_RED],   255);
+  g = scale_round (priv->color[COLORSEL_GREEN], 255);
+  b = scale_round (priv->color[COLORSEL_BLUE],  255);
+  g_snprintf (entryval, 11, "#%2X%2X%2X", (guint) r, (guint) g, (guint) b);
 
   for (ptr = entryval; *ptr; ptr++)
     if (*ptr == ' ')

--- a/libmate-desktop/mate-hsv.c
+++ b/libmate-desktop/mate-hsv.c
@@ -825,9 +825,9 @@ paint_ring (MateHSV *hsv,
           b = 1.0;
           hsv_to_rgb (&r, &g, &b);
 
-          *p++ = (((int)floor (r * 255 + 0.5) << 16) |
-                  ((int)floor (g * 255 + 0.5) << 8) |
-                  (int)floor (b * 255 + 0.5));
+          *p++ = (((int)(r * 255.0) << 16) |
+                  ((int)(g * 255.0) << 8) |
+                  (int)(b * 255.0));
         }
     }
 

--- a/libmate-desktop/mate-languages.c
+++ b/libmate-desktop/mate-languages.c
@@ -556,6 +556,24 @@ collect_locales_from_localebin (void)
 }
 
 static void
+fill_count_map (GHashTable *count_map,
+                const char *code)
+{
+        int count;
+        gpointer pointer;
+
+        if (code == NULL)
+                return;
+
+        if ((pointer = g_hash_table_lookup (count_map, code)) != NULL)
+                count = GPOINTER_TO_INT (pointer) + 1;
+        else
+                count = 1;
+
+        g_hash_table_insert (count_map, g_strdup (code), GINT_TO_POINTER (count));
+}
+
+static void
 count_languages_and_territories (void)
 {
 	gpointer value;
@@ -566,25 +584,9 @@ count_languages_and_territories (void)
 
         g_hash_table_iter_init (&iter, mate_available_locales_map);
         while (g_hash_table_iter_next (&iter, NULL, &value)) {
-                MateLocale *locale;
-
-                locale = (MateLocale *) value;
-
-		if (locale->language_code != NULL) {
-			int count;
-
-			count = GPOINTER_TO_INT (g_hash_table_lookup (mate_language_count_map, locale->language_code));
-			count++;
-			g_hash_table_insert (mate_language_count_map, g_strdup (locale->language_code), GINT_TO_POINTER (count));
-		}
-
-		if (locale->territory_code != NULL) {
-			int count;
-
-			count = GPOINTER_TO_INT (g_hash_table_lookup (mate_territory_count_map, locale->territory_code));
-			count++;
-			g_hash_table_insert (mate_territory_count_map, g_strdup (locale->territory_code), GINT_TO_POINTER (count));
-		}
+                MateLocale *locale = (MateLocale *) value;
+                fill_count_map (mate_language_count_map, locale->language_code);
+                fill_count_map (mate_territory_count_map, locale->territory_code);
         }
 }
 
@@ -614,11 +616,16 @@ collect_locales (void)
 static gint
 get_language_count (const char *language)
 {
-        if (mate_language_count_map == NULL) {
-                collect_locales ();
-        }
+        gint count = 0;
+        gpointer pointer;
 
-	return GPOINTER_TO_INT (g_hash_table_lookup (mate_language_count_map, language));
+        if (mate_language_count_map == NULL)
+                collect_locales ();
+
+        if ((pointer = g_hash_table_lookup (mate_language_count_map, language)) != NULL)
+                count = GPOINTER_TO_INT (pointer);
+
+        return count;
 }
 
 static gboolean
@@ -630,11 +637,16 @@ is_unique_language (const char *language)
 static gint
 get_territory_count (const char *territory)
 {
-        if (mate_territory_count_map == NULL) {
-                collect_locales ();
-        }
+        gint count = 0;
+        gpointer pointer;
 
-	return GPOINTER_TO_INT (g_hash_table_lookup (mate_territory_count_map, territory));
+        if (mate_territory_count_map == NULL)
+                collect_locales ();
+
+        if ((pointer = g_hash_table_lookup (mate_territory_count_map, territory)) != NULL)
+                count = GPOINTER_TO_INT (pointer);
+
+        return count;
 }
 
 static gboolean


### PR DESCRIPTION
```
mate-bg.c: In function ‘get_pixbuf_for_size’:
mate-bg.c:2383:30: warning: cast from function call of type ‘double’ to non-matching type ‘unsigned int’ [-Wbad-function-cast]
 2383 |     time_until_next_change = (guint)get_slide_timeout (slide);
      |                              ^
mate-languages.c: In function ‘count_languages_and_territories’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-languages.c:576:12: note: in expansion of macro ‘GPOINTER_TO_INT’
  576 |    count = GPOINTER_TO_INT (g_hash_table_lookup (mate_language_count_map, locale->language_code));
      |            ^~~~~~~~~~~~~~~
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-languages.c:584:12: note: in expansion of macro ‘GPOINTER_TO_INT’
  584 |    count = GPOINTER_TO_INT (g_hash_table_lookup (mate_territory_count_map, locale->territory_code));
      |            ^~~~~~~~~~~~~~~
mate-languages.c: In function ‘get_language_count’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-languages.c:621:9: note: in expansion of macro ‘GPOINTER_TO_INT’
  621 |  return GPOINTER_TO_INT (g_hash_table_lookup (mate_language_count_map, language));
      |         ^~~~~~~~~~~~~~~
mate-languages.c: In function ‘get_territory_count’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-languages.c:637:9: note: in expansion of macro ‘GPOINTER_TO_INT’
  637 |  return GPOINTER_TO_INT (g_hash_table_lookup (mate_territory_count_map, territory));
      |         ^~~~~~~~~~~~~~~
mate-hsv.c:828:20: warning: cast from function call of type ‘double’ to non-matching type ‘int’ [-Wbad-function-cast]
  828 |           *p++ = (((int)floor (r * 255 + 0.5) << 16) |
      |                    ^
mate-hsv.c:829:20: warning: cast from function call of type ‘double’ to non-matching type ‘int’ [-Wbad-function-cast]
  829 |                   ((int)floor (g * 255 + 0.5) << 8) |
      |                    ^
mate-hsv.c:830:19: warning: cast from function call of type ‘double’ to non-matching type ‘int’ [-Wbad-function-cast]
  830 |                   (int)floor (b * 255 + 0.5));
      |                   ^
mate-colorsel.c: In function ‘palette_set_color’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-colorsel.c:1263:7: note: in expansion of macro ‘GPOINTER_TO_INT’
 1263 |   if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (drawing_area), "color_set")) == 0)
      |       ^~~~~~~~~~~~~~~
mate-colorsel.c: In function ‘palette_release’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-colorsel.c:1461:11: note: in expansion of macro ‘GPOINTER_TO_INT’
 1461 |       if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (drawing_area), "color_set")) != 0)
      |           ^~~~~~~~~~~~~~~
mate-colorsel.c: In function ‘palette_activate’:
/usr/lib64/glib-2.0/include/glibconfig.h:98:37: warning: cast from function call of type ‘gpointer’ {aka ‘void *’} to non-matching type ‘long int’ [-Wbad-function-cast]
   98 | #define GPOINTER_TO_INT(p) ((gint)  (glong) (p))
      |                                     ^
mate-colorsel.c:1520:11: note: in expansion of macro ‘GPOINTER_TO_INT’
 1520 |       if (GPOINTER_TO_INT (g_object_get_data (G_OBJECT (widget), "color_set")) != 0)
      |           ^~~~~~~~~~~~~~~
mate-colorsel.c: In function ‘update_color’:
mate-colorsel.c:2164:8: warning: cast from function call of type ‘double’ to non-matching type ‘unsigned int’ [-Wbad-function-cast]
 2164 |        (guint) (scale_round (priv->color[COLORSEL_RED], 255)),
      |        ^
mate-colorsel.c:2165:8: warning: cast from function call of type ‘double’ to non-matching type ‘unsigned int’ [-Wbad-function-cast]
 2165 |        (guint) (scale_round (priv->color[COLORSEL_GREEN], 255)),
      |        ^
mate-colorsel.c:2166:8: warning: cast from function call of type ‘double’ to non-matching type ‘unsigned int’ [-Wbad-function-cast]
 2166 |        (guint) (scale_round (priv->color[COLORSEL_BLUE], 255)));
      |        ^
```