### PR TITLE
Remove shadow warnings [-Wshadow]

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -3071,7 +3071,7 @@ read_slideshow_file (const char *filename,
 	g_markup_parse_context_free (context);
 
 	if (show) {
-		int len;
+		guint num_items;
 
 		t = mktime (&show->start_tm);
 
@@ -3079,14 +3079,14 @@ read_slideshow_file (const char *filename,
 
 		dump_bg (show);
 
-		len = g_queue_get_length (show->slides);
+		num_items = g_queue_get_length (show->slides);
 
 		/* no slides, that's not a slideshow */
-		if (len == 0) {
+		if (num_items == 0) {
 			slideshow_unref (show);
 			show = NULL;
 		/* one slide, there's no transition */
-		} else if (len == 1) {
+		} else if (num_items == 1) {
 			Slide *slide = show->slides->head->data;
 			slide->duration = show->total_duration = G_MAXUINT;
 		}

--- a/libmate-desktop/mate-rr-config.c
+++ b/libmate-desktop/mate-rr-config.c
@@ -1546,7 +1546,7 @@ crtc_assignment_assign (CrtcAssignment   *assign,
     }
     else
     {
-	CrtcInfo *info = g_new0 (CrtcInfo, 1);
+	info = g_new0 (CrtcInfo, 1);
 
 	info->mode = mode;
 	info->x = x;

--- a/libmate-desktop/mate-rr.c
+++ b/libmate-desktop/mate-rr.c
@@ -376,9 +376,7 @@ fill_screen_info_from_resources (ScreenInfo *info,
     a = g_ptr_array_new ();
     for (i = 0; i < resources->ncrtc; ++i)
     {
-	MateRRCrtc *crtc = crtc_new (info, resources->crtcs[i]);
-
-	g_ptr_array_add (a, crtc);
+	g_ptr_array_add (a, crtc_new (info, resources->crtcs[i]));
     }
     g_ptr_array_add (a, NULL);
     info->crtcs = (MateRRCrtc **)g_ptr_array_free (a, FALSE);
@@ -386,9 +384,7 @@ fill_screen_info_from_resources (ScreenInfo *info,
     a = g_ptr_array_new ();
     for (i = 0; i < resources->noutput; ++i)
     {
-	MateRROutput *output = output_new (info, resources->outputs[i]);
-
-	g_ptr_array_add (a, output);
+	g_ptr_array_add (a, output_new (info, resources->outputs[i]));
     }
     g_ptr_array_add (a, NULL);
     info->outputs = (MateRROutput **)g_ptr_array_free (a, FALSE);


### PR DESCRIPTION
```
mate-bg.c:3074:7: warning: declaration of ‘len’ shadows a previous local [-Wshadow]
 3074 |   int len;
      |       ^~~
mate-bg.c:3035:8: note: shadowed declaration is here
--
mate-rr.c:379:14: warning: declaration of ‘crtc’ shadows a previous local [-Wshadow]
  379 |  MateRRCrtc *crtc = crtc_new (info, resources->crtcs[i]);
      |              ^~~~
mate-rr.c:368:18: note: shadowed declaration is here
--
mate-rr.c:389:16: warning: declaration of ‘output’ shadows a previous local [-Wshadow]
  389 |  MateRROutput *output = output_new (info, resources->outputs[i]);
      |                ^~~~~~
mate-rr.c:369:20: note: shadowed declaration is here
--
mate-rr-config.c:1549:12: warning: declaration of ‘info’ shadows a previous local [-Wshadow]
 1549 |  CrtcInfo *info = g_new0 (CrtcInfo, 1);
      |            ^~~~
```