### PR TITLE
MATE About: Fix off-by-one error, display yerba mate comment

### DIFF
--- a/mate-about/mate-about.c
+++ b/mate-about/mate-about.c
@@ -58,7 +58,7 @@ void mate_about_run(void)
      * The comments index must not be more than comments_count - 1
      */
     gtk_about_dialog_set_comments (mate_about_dialog,
-                                   _(comments_array[g_random_int_range (0, comments_count - 1)]));
+                                   _(comments_array[g_random_int_range (0, comments_count)]));
 
     gtk_about_dialog_set_authors(mate_about_dialog, authors);
     gtk_about_dialog_set_artists(mate_about_dialog, artists);


### PR DESCRIPTION
The MATE About program is designed to display one of six messages at random
each time you launch the application, showcasing the fundamental values of
the MATE Project.  Unfortunately, due to an off-by-one programming error
introduced many years ago, only the first five messages ever get displayed;
the sixth message, referring to where MATE got its name from, is never chosen.
This was due to a misunderstanding of the GLib function `g_random_int_range`:
The function is and always was designed to be passed an inclusive lower and
an exclusive upper value for the random integer, generating a random integer
that is greater than or equal to the lower value and less than the upper value
specified.  The MATE About application errantly subtracted 1 from the upper
value itself, and thus only messages 1 through 5 were ever picked.

This commit removes the unnecessary subtraction.