### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -898,7 +898,7 @@ static void
 color_sample_setup_dnd (MateColorSelection *colorsel, GtkWidget *sample)
 {
   static const GtkTargetEntry targets[] = {
-    { "application/x-color", 0 }
+    { .target = "application/x-color", .flags = 0, .info = 0 }
   };
   MateColorSelectionPrivate *priv;
   priv = colorsel->private_data;
@@ -1265,7 +1265,7 @@ palette_set_color (GtkWidget         *drawing_area,
   if (!pointer || GPOINTER_TO_INT (pointer) == 0)
     {
       static const GtkTargetEntry targets[] = {
-	{ "application/x-color", 0 }
+	{ .target = "application/x-color", .flags = 0, .info = 0 }
       };
       gtk_drag_source_set (drawing_area,
 			   GDK_BUTTON1_MASK | GDK_BUTTON3_MASK,
@@ -1548,7 +1548,7 @@ static GtkWidget*
 palette_new (MateColorSelection *colorsel)
 {
   static const GtkTargetEntry targets[] = {
-    { "application/x-color", 0 }
+    { .target = "application/x-color", .flags = 0, .info = 0 }
   };
 
   GtkWidget *retval = gtk_drawing_area_new ();

--- a/mate-about/mate-about.h.in
+++ b/mate-about/mate-about.h.in
@@ -664,7 +664,7 @@ static void mate_about_on_activate(GtkApplication* app);
 // arguments definitions
 static GOptionEntry command_entries[] = {
     {"version", 'v', 0, G_OPTION_ARG_NONE, &mate_about_nogui, "Show MATE version", NULL},
-    {NULL}
+    {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 };
 
 #endif /* __MATE_ABOUT_H__ */


### PR DESCRIPTION
```
mate-colorsel.c:901:32: warning: missing field 'info' initializer [-Wmissing-field-initializers]
    { "application/x-color", 0 }
                               ^
--
mate-colorsel.c:1268:29: warning: missing field 'info' initializer [-Wmissing-field-initializers]
        { "application/x-color", 0 }
                                   ^
--
mate-colorsel.c:1551:32: warning: missing field 'info' initializer [-Wmissing-field-initializers]
    { "application/x-color", 0 }
                               ^
--
./mate-about.h:667:10: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
    {NULL}
         ^
```