### PR TITLE
mate-bg: fix memory leak

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -3197,9 +3197,13 @@ mate_bg_changes_with_time (MateBG *bg)
 	if (!bg->filename)
 		return FALSE;
 
-	show = get_as_slideshow (bg, bg->filename);
-	if (show)
-		return g_queue_get_length (show->slides) > 1;
+	if ((show = get_as_slideshow (bg, bg->filename)) != NULL) {
+		gboolean result;
+
+		result = (g_queue_get_length (show->slides) > 1) ? TRUE : FALSE;
+		slideshow_unref (show);
+		return result;
+	}
 
 	return FALSE;
 }


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 416 byte(s) in 4 object(s) allocated from:
    #0 0x7fb34c5f3af7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fb34aec8584 in g_malloc0 ../glib/gmem.c:136
    #2 0x7fb34aec88d2 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7fb34c2c0684 in read_slideshow_file /home/robert/builddir.gcc/mate-desktop/libmate-desktop/mate-bg.c:3051
    #4 0x7fb34c2bae57 in get_as_slideshow /home/robert/builddir.gcc/mate-desktop/libmate-desktop/mate-bg.c:1989
    #5 0x7fb34c2c1092 in mate_bg_changes_with_time /home/robert/builddir.gcc/mate-desktop/libmate-desktop/mate-bg.c:3200
    #6 0x42b64a in mate_wp_item_update_description /home/robert/builddir.gcc/mate-control-center/capplets/appearance/mate-wp-item.c:295
    #7 0x42d324 in mate_wp_xml_load_xml /home/robert/builddir.gcc/mate-control-center/capplets/appearance/mate-wp-xml.c:327
    #8 0x42da21 in mate_wp_xml_load_list /home/robert/builddir.gcc/mate-control-center/capplets/appearance/mate-wp-xml.c:433
    #9 0x4150c3 in wp_load_stuffs /home/robert/builddir.gcc/mate-control-center/capplets/appearance/appearance-desktop.c:939
    #10 0x7fb34aeb9f2e in g_idle_dispatch ../glib/gmain.c:5929
    #11 0x7fb34aebf136 in g_main_dispatch ../glib/gmain.c:3413
    #12 0x7fb34aebef7f in g_main_context_dispatch ../glib/gmain.c:4131
    #13 0x7fb34aebf4a1 in g_main_context_iterate ../glib/gmain.c:4207
    #14 0x7fb34aebf9c2 in g_main_loop_run ../glib/gmain.c:4405
    #15 0x7fb34b878e1c in gtk_main (/lib64/libgtk-3.so.0+0x248e1c)
```