### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/libmate-desktop/mate-colorbutton.c
+++ b/libmate-desktop/mate-colorbutton.c
@@ -763,7 +763,7 @@ mate_color_button_set_use_alpha (MateColorButton *color_button,
 
   if (color_button->priv->use_alpha != use_alpha)
     {
-      color_button->priv->use_alpha = use_alpha;
+      color_button->priv->use_alpha = (use_alpha != FALSE);
 
       gtk_widget_queue_draw (color_button->priv->draw_area);
 

--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -2336,7 +2336,7 @@ mate_color_selection_set_has_opacity_control (MateColorSelection *colorsel,
 
   if (priv->has_opacity != has_opacity)
     {
-      priv->has_opacity = has_opacity;
+      priv->has_opacity = (has_opacity != FALSE);
       if (has_opacity)
 	{
 	  gtk_widget_show (priv->opacity_slider);
@@ -2395,7 +2395,7 @@ mate_color_selection_set_has_palette (MateColorSelection *colorsel,
 
   if (priv->has_palette != has_palette)
     {
-      priv->has_palette = has_palette;
+      priv->has_palette = (has_palette != FALSE);
       if (has_palette)
 	gtk_widget_show (priv->palette_frame);
       else


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
mate-colorbutton.c:766:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      color_button->priv->use_alpha = use_alpha;
                                    ~ ^~~~~~~~~
--
mate-colorsel.c:2339:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      priv->has_opacity = has_opacity;
                        ~ ^~~~~~~~~~~
mate-colorsel.c:2398:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
      priv->has_palette = has_palette;
                        ~ ^~~~~~~~~~~
```