### PR TITLE
Remove some build warnings about unused macros

### DIFF
--- a/libmate-desktop/mate-bg.c
+++ b/libmate-desktop/mate-bg.c
@@ -75,10 +75,6 @@ struct _FileSize {
 	char* file;
 };
 
-/* This is the size of the GdkRGB dither matrix, in order to avoid
- * bad dithering when tiling the gradient
- */
-#define GRADIENT_PIXMAP_TILE_SIZE 128
 #define THUMBNAIL_SIZE 256
 
 typedef struct FileCacheEntry FileCacheEntry;

--- a/libmate-desktop/mate-colorsel.c
+++ b/libmate-desktop/mate-colorsel.c
@@ -53,8 +53,6 @@
 #define DROPPER_X_HOT 2
 #define DROPPER_Y_HOT 16
 
-#define SAMPLE_WIDTH  64
-#define SAMPLE_HEIGHT 28
 #define CHECK_SIZE 16
 #define BIG_STEP 20
 

--- a/libmate-desktop/mate-desktop-item.c
+++ b/libmate-desktop/mate-desktop-item.c
@@ -52,8 +52,6 @@
 #include <gtk/gtk.h>
 #endif
 
-#define sure_string(s) ((s)!=NULL?(s):"")
-
 #define MATE_DESKTOP_USE_UNSTABLE_API
 #undef MATE_DISABLE_DEPRECATED
 #include <mate-desktop-item.h>


### PR DESCRIPTION
```
mate-bg.c:81:9: warning: macro is not used [-Wunused-macros]
#define GRADIENT_PIXMAP_TILE_SIZE 128
        ^
--
mate-colorsel.c:57:9: warning: macro is not used [-Wunused-macros]
#define SAMPLE_HEIGHT 28
        ^
mate-colorsel.c:56:9: warning: macro is not used [-Wunused-macros]
#define SAMPLE_WIDTH  64
        ^
--
mate-desktop-item.c:55:9: warning: macro is not used [-Wunused-macros]
#define sure_string(s) ((s)!=NULL?(s):"")
        ^
```