### PR TITLE
Add setting for adjustment of audio volume above 100 per cent:  Part 1

### DIFF
--- a/schemas/org.mate.sound.gschema.xml
+++ b/schemas/org.mate.sound.gschema.xml
@@ -30,5 +30,17 @@
       <summary>Input feedback sounds</summary>
       <description>Whether to play sounds on input events.</description>
     </key>
+    <key name="volume-overamplifiable" type="b">
+      <default>false</default>
+      <summary>Permit the output volume to exceed 100%</summary>
+      <description>
+        If this is set to TRUE, the user will be allowed to set the output /
+        speaker volume to above 100%.  By setting the output volume above
+        100%, the sound server will amplify the audio above what the audio
+        hardware can do cleanly.  This can lead to audio quality degradation,
+        but may be useful for listening to extremely quiet audio recordings,
+        where the recording would otherwise be completely useless.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
There is often a need for the user to increase the audio playback volume above
the volume level known as "100% volume".  While increasing the audio volume
above 100% can result in degraded audio quality, sometimes the audio was, for
example, originally recorded at an extremely low volume, and the user has no
other option to clearly hear the audio.  Unfortunately, most MATE applications
with volume controls do not allow the user to set the volume level above 100%.
For example, the main MATE Sound Preferences dialog lets you set the audio
volume beyond 100% (when possible), whereas the Volume Control Applet, Volume
Control status icon, and special "multimedia" volume control keys do not.  In
fact, if the user even tries to change the volume using any of the latter
methods, and the current volume level is above 100%, these latter methods will
all reduce the volume to 100%, even if the user tried to increase the volume!

This is part 1 of a patch to change this situation.  All that this patch does
is add a new, standard MATE setting which determines whether the user should
be allowed to set the audio volume above 100%.  The rest of the functionality
of this patch is in other commits / pull requests.

Part 2:  https://github.com/mate-desktop/mate-media/pull/191
Part 3:  https://github.com/mate-desktop/mate-settings-daemon/pull/389

When all three parts are applied, https://github.com/mate-desktop/mate-desktop/issues/246 can be closed.