### PR TITLE
add xdg-desktop-portal config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libmate-desktop man docs schemas tools icons po
+SUBDIRS = libmate-desktop man docs schemas tools icons po xdg-portal
 
 if MATE_ABOUT_ENABLED
 SUBDIRS += mate-about

--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,7 @@ schemas/org.mate.background.gschema.xml
 man/Makefile
 tools/Makefile
 icons/Makefile
+xdg-portal/Makefile
 ])
 
 AC_OUTPUT

--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,7 @@ endif
 subdir('po')
 subdir('tools')
 subdir('schemas')
+subdir('xdg-portal')
 if get_option('mate-about')
   subdir('mate-about')
 endif

--- a/xdg-portal/Makefile.am
+++ b/xdg-portal/Makefile.am
@@ -1,0 +1,5 @@
+NULL =
+
+xdgportaldir = $(datadir)/xdg-desktop-portal
+dist_xdgportal_DATA = mate-portals.conf
+

--- a/xdg-portal/mate-portals.conf
+++ b/xdg-portal/mate-portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+default=gtk;
+org.freedesktop.impl.portal.Secret=gnome-keyring;

--- a/xdg-portal/meson.build
+++ b/xdg-portal/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  'mate-portals.conf',
+  install_dir: join_paths(get_option('datadir'), 'xdg-desktop-portal'),
+)


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-desktop/issues/574

This installs a mate-portals.conf for xdg-desktop-portal >= 1.17, indicating that MATE recommended portal backend for use with MATE. Recommendation is currently [x-d-p-gtk](https://github.com/flatpak/xdg-desktop-portal-gtk).
Edit:
The mate.portals.conf file is a replacement for the UseIn key inside the portal implementation files; it is also a replacement for people disabling unwanted portal support.