### PR TITLE
Fix compilation warning replace gtk_style_context_get_background_color

### DIFF
--- a/libmate-desktop/mate-bg-crossfade.c
+++ b/libmate-desktop/mate-bg-crossfade.c
@@ -278,7 +278,7 @@ tile_surface (cairo_surface_t *surface,
         gtk_style_context_add_provider (context,
                                         GTK_STYLE_PROVIDER (provider),
                                         GTK_STYLE_PROVIDER_PRIORITY_THEME);
-        gtk_style_context_get_background_color (context, GTK_STATE_FLAG_NORMAL, &bg);
+        gtk_style_context_get (context, GTK_STATE_FLAG_NORMAL, "background-color", &bg, NULL);
         gdk_cairo_set_source_rgba(cr, &bg);
         g_object_unref (G_OBJECT (context));
     }

--- a/libmate-desktop/mate-desktop-utils.c
+++ b/libmate-desktop/mate-desktop-utils.c
@@ -447,7 +447,10 @@ mate_desktop_gtk_style_get_light_color (GtkStyleContext *style,
                                         GtkStateFlags    state,
                                         GdkRGBA         *color)
 {
-	gtk_style_context_get_background_color (style, state, color);
+	g_return_if_fail (color !=  NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (style));
+
+	gtk_style_context_get (style, state, "background-color", &color, NULL);
 	gtk_style_shade (color, color, LIGHTNESS_MULT);
 }
 
@@ -456,6 +459,9 @@ mate_desktop_gtk_style_get_dark_color (GtkStyleContext *style,
                                        GtkStateFlags    state,
                                        GdkRGBA         *color)
 {
-	gtk_style_context_get_background_color (style, state, color);
+	g_return_if_fail (color !=  NULL);
+	g_return_if_fail (GTK_IS_STYLE_CONTEXT (style));
+
+	gtk_style_context_get (style, state, "background-color", &color, NULL);
 	gtk_style_shade (color, color, DARKNESS_MULT);
 }


### PR DESCRIPTION
Fix compilation warning，Test normal using ```mate-display-properties```