### PR TITLE
mate-colorseldialog: Fix compilation warnings remove deprecated function

### DIFF
--- a/libmate-desktop/mate-colorseldialog.c
+++ b/libmate-desktop/mate-colorseldialog.c
@@ -147,9 +147,7 @@ mate_color_selection_dialog_init (MateColorSelectionDialog *colorseldiag)
   _mate_desktop_init_i18n ();
 
   gtk_container_set_border_width (GTK_CONTAINER (dialog), 5);
-  gtk_box_set_spacing (GTK_BOX (gtk_dialog_get_content_area (dialog)), 2); /* 2 * 5 + 2 = 12 */
-  gtk_container_set_border_width (GTK_CONTAINER (gtk_dialog_get_action_area (dialog)), 5);
-  gtk_box_set_spacing (GTK_BOX (gtk_dialog_get_action_area (dialog)), 6);
+  gtk_box_set_spacing (GTK_BOX (gtk_dialog_get_content_area (dialog)), 6);
 
   colorseldiag->colorsel = mate_color_selection_new ();
   gtk_container_set_border_width (GTK_CONTAINER (colorseldiag->colorsel), 5);


### PR DESCRIPTION
```gtk_dialog_get_action_area``` has been deprecated