### PR TITLE
wayland: fix uninitialized variable

### DIFF
--- a/libmate-desktop/mate-desktop-item.c
+++ b/libmate-desktop/mate-desktop-item.c
@@ -1873,6 +1873,10 @@ ditem_execute (const MateDesktopItem *item,
 			sn_context = NULL;
 		}
 	}
+	else {
+		sn_context = NULL;
+		sn_display = NULL;
+	}
 #endif
 
 	if (screen) {


### PR DESCRIPTION
We still have sn_display in the runtime checks to determine whether to call the startup notification, so we have to initialize it to NULL in the wayland case.