### PR TITLE
meson: Add meson support for static library

### DIFF
--- a/libmate-desktop/meson.build
+++ b/libmate-desktop/meson.build
@@ -88,7 +88,7 @@ if cc.has_link_argument(test_ldflag)
   ldflags += test_ldflag
 endif
 
-libmate_desktop = shared_library(
+libmate_desktop = library(
   'mate-desktop-2',
   sources: sources,
   version: libversion,


### PR DESCRIPTION
Should add support for building static libraries in ```meson```

## test
```
meson build -Ddefault_library=both
```