### PR TITLE
xdg-portal: add meson.build to EXTRA_DIST

### DIFF
--- a/xdg-portal/Makefile.am
+++ b/xdg-portal/Makefile.am
@@ -3,3 +3,5 @@ NULL =
 xdgportaldir = $(datadir)/xdg-desktop-portal
 dist_xdgportal_DATA = mate-portals.conf
 
+EXTRA_DIST = \
+	meson.build


### PR DESCRIPTION
Follow-up of 287fdce6d430 ("add xdg-desktop-portal config file")

Unbreaks meson build using release tarball:

```
meson.build:109:0: ERROR: Nonexistent build file 'xdg-portal/meson.build'
```

Closes #600

Tested make dist :

<img src="https://github.com/mate-desktop/mate-desktop/assets/20080233/23076bbc-55b2-4d46-800f-5529777cbb97" width=70%>

<img src="https://github.com/mate-desktop/mate-desktop/assets/20080233/1253f37b-b632-43ce-82da-b5b91f353ab1" width=50%>

Tested building with autotools and meson using the tarball
