### PR TITLE
mate-rr: Add hotplug_mode_update output property

### DIFF
--- a/libmate-desktop/mate-rr-private.h
+++ b/libmate-desktop/mate-rr-private.h
@@ -47,6 +47,7 @@ struct MateRRScreenPrivate
     int				rr_minor_version;
 
     Atom                        connector_type_atom;
+    Atom                        hotplug_mode_update_atom;
 };
 
 struct MateRROutputInfoPrivate

--- a/libmate-desktop/mate-rr.c
+++ b/libmate-desktop/mate-rr.c
@@ -90,6 +90,7 @@ struct MateRROutput
     guint8 *		edid_data;
     int         edid_size;
     char *              connector_type;
+    gboolean            hotplug_mode_update;
 };
 
 struct MateRROutputWrap
@@ -667,6 +668,7 @@ mate_rr_screen_initable_init (GInitable *initable, GCancellable *canc, GError **
     int ignore;
 
     priv->connector_type_atom = XInternAtom (dpy, "ConnectorType", FALSE);
+    priv->hotplug_mode_update_atom = XInternAtom (dpy, "hotplug_mode_update", FALSE);
 
 #ifdef HAVE_RANDR
     if (XRRQueryExtension (dpy, &event_base, &ignore))
@@ -1243,6 +1245,31 @@ out:
 #endif
 }
 
+static gboolean
+get_hotplug_mode_update (MateRROutput *output)
+{
+#ifdef HAVE_RANDR
+    XRRPropertyInfo *info;
+    GdkDisplay *display;
+
+    display = gdk_display_get_default ();
+    gdk_x11_display_error_trap_push (display);
+    info = XRRQueryOutputProperty (DISPLAY (output), output->id,
+                                   output->info->screen->priv->hotplug_mode_update_atom);
+    gdk_display_flush (display);
+    if (gdk_x11_display_error_trap_pop (display))
+        return FALSE;
+
+    if (info)
+    {
+        XFree (info);
+        return TRUE;
+    }
+#endif
+
+    return FALSE;
+}
+
 #ifdef HAVE_RANDR
 static gboolean
 output_initialize (MateRROutput *output, XRRScreenResources *res, GError **error)
@@ -1272,6 +1299,7 @@ output_initialize (MateRROutput *output, XRRScreenResources *res, GError **error
     output->height_mm = info->mm_height;
     output->connected = (info->connection == RR_Connected);
     output->connector_type = get_connector_type_string (output);
+    output->hotplug_mode_update = get_hotplug_mode_update (output);
 
     /* Possible crtcs */
     a = g_ptr_array_new ();
@@ -1339,6 +1367,7 @@ output_copy (const MateRROutput *from)
     output->connected = from->connected;
     output->n_preferred = from->n_preferred;
     output->connector_type = g_strdup (from->connector_type);
+    output->hotplug_mode_update = from->hotplug_mode_update;
 
     array = g_ptr_array_new ();
     for (p_crtc = from->possible_crtcs; *p_crtc != NULL; p_crtc++)
@@ -1456,6 +1485,24 @@ mate_rr_output_get_connector_type (MateRROutput *output)
     g_return_val_if_fail (output != NULL, NULL);
 
     return output->connector_type;
+}
+
+/**
+ * mate_rr_output_get_hotplug_mode_update:
+ * @output: a #MateRROutput
+ *
+ * Returns whether the output has the hotplug_mode_update property,
+ * which indicates that the display should apply a new preferred mode
+ * on hotplug events to handle dynamic guest resizing in virtual machines.
+ *
+ * Returns: %TRUE if the output has hotplug_mode_update
+ */
+gboolean
+mate_rr_output_get_hotplug_mode_update (MateRROutput *output)
+{
+    g_return_val_if_fail (output != NULL, FALSE);
+
+    return output->hotplug_mode_update;
 }
 
 gboolean

--- a/libmate-desktop/mate-rr.h
+++ b/libmate-desktop/mate-rr.h
@@ -136,6 +136,7 @@ MateRRMode *   mate_rr_output_get_current_mode   (MateRROutput         *output);
 MateRRCrtc *   mate_rr_output_get_crtc           (MateRROutput         *output);
 const char *    mate_rr_output_get_connector_type (MateRROutput         *output);
 gboolean        mate_rr_output_is_laptop          (MateRROutput         *output);
+gboolean        mate_rr_output_get_hotplug_mode_update (MateRROutput    *output);
 void            mate_rr_output_get_position       (MateRROutput         *output,
 						    int                   *x,
 						    int                   *y);


### PR DESCRIPTION
Expose the RandR hotplug_mode_update property on MateRROutput so consumers can check whether an output supports dynamic mode updates on hotplug events (e.g. virtual machine guest resizing).

This is inspired by https://gitlab.gnome.org/GNOME/mutter/-/commit/957513242c26be458be7a101b83180e3f59f6a44 but made more generic so that m-s-d can handle the property and eventually fix mate-desktop/mate-settings-daemon#78